### PR TITLE
feat: Don't add duplicates to list when remapping

### DIFF
--- a/src/music_modify/utils/list_utils.py
+++ b/src/music_modify/utils/list_utils.py
@@ -114,11 +114,12 @@ def remapMatchingSublistPairs(
         return original
     if index < 0 or index >= constants.PEOPLE_COL_COUNT:
         return original
-    return [
-        [
+    new_values: list[list[str]] = []
+    for item in original:
+        possible_value = [
             replacements.get(item[0], item[0]) if index == 0 else item[0],
             replacements.get(item[1], item[1]) if index == 1 else item[1],
         ]
-        for item in original
-    ]
-    # TODO: Don't add item if already present, remove instead
+        if possible_value not in new_values:
+            new_values.append(possible_value)
+    return new_values

--- a/tests/utils/test_list_utils.py
+++ b/tests/utils/test_list_utils.py
@@ -306,6 +306,33 @@ def test_removeMatchingSublistPairs(
             _original_list,
             id="invalid_low_index_no_op",
         ),
+        pytest.param(
+            {"Person2": "Person1"},
+            _original_list,
+            PairIndex.Person.value,
+            [
+                ["role1", "Person1"],
+                ["role2", "Person3"],
+                ["role3", "Person1"],
+            ],
+            id="not_add_if_already_present_and_other",
+        ),
+        pytest.param(
+            {"PersonA": "Person1"},
+            [
+                ["role1", "Person1"],
+                ["role1", "PersonA"],
+                ["role2", "Person3"],
+                ["role3", "Person2"],
+            ],
+            PairIndex.Person.value,
+            [
+                ["role1", "Person1"],
+                ["role2", "Person3"],
+                ["role3", "Person2"],
+            ],
+            id="not_add_if_already_present",
+        ),
     ],
 )
 def test_remapMatchingSublistPairs(


### PR DESCRIPTION
If remapping causes there to be a duplicate in the list, only the first instance is kept, rather than adding a duplicate.