### PR TITLE
feat: Add EditorType enum

### DIFF
--- a/src/music_modify/custom_types/enums.py
+++ b/src/music_modify/custom_types/enums.py
@@ -12,6 +12,18 @@ class TagType(Enum):
     Url = "url"
 
 
+class EditorType(Enum):
+    """The type of widget/display that should be used for editing a tag.
+
+    Should only contain the types that can actually be handled.
+    """
+
+    Automatic = "Determine the editor based on tag data."
+    SingleText = "Tags storing single values."
+    MultipleText = "Tags storing multiple values."
+    PeopleValue = "Tags storing role, person pairs."
+
+
 class RowDirection(Enum):
     """Direction that a row should move, when a button is clicked."""
 

--- a/src/music_modify/custom_types/songtag.py
+++ b/src/music_modify/custom_types/songtag.py
@@ -13,7 +13,7 @@ from .aliases import (
     SongListData,
     SongTableData,
 )
-from .enums import TagType
+from .enums import EditorType, TagType
 
 logger = logging.getLogger(__name__)
 
@@ -36,16 +36,26 @@ class SongTag:
     """List of keys that store a list of strings,
     rather than a single value."""
 
-    def __init__(self, *, display_name: str, id3_key: str) -> None:
+    def __init__(
+        self,
+        *,
+        display_name: str,
+        id3_key: str,
+        editor_type: EditorType = EditorType.Automatic,
+    ) -> None:
         """Create a `SongTag` based on a display name and key.
 
         Args:
             display_name: The human-readable name for the tag
             id3_key: The field in an id3 object that this tag refers to
+            editor_type: The kind of widget the data for this tag is displayed with
         """
         self._id3_key: Final[str] = id3_key
         self._display_name: Final[str] = display_name
         self._frame_type: Final[TagType] = SongTag._getFrameType(id3_key)
+        self._editor_type: Final[EditorType] = SongTag._calculateEditorType(
+            editor_type, id3_key
+        )
 
     @override
     def __repr__(self) -> str:
@@ -78,16 +88,16 @@ class SongTag:
         """The kind of metadata that the tag will store."""
         return self._frame_type
 
-    @property
-    def allow_multiple(self) -> bool:
-        """Returns `True` if this tag stores a list of values.
-
-        Tags can either store a list of strings, a string, or a list of string pairs.
-        This property is used to determine when a tag stores a list of strings.
-        Note that it returns `False` if the tag stores a string _or_ string pairs.
-        """
-        # TODO: Consider whether people tags should return True here.
-        return self.id3_key in SongTag.KEYS_ALLOW_MULTIPLE_VALUES
+    @staticmethod
+    def _calculateEditorType(editor_type: EditorType, key: str) -> EditorType:
+        if editor_type != EditorType.Automatic:
+            return editor_type
+        frame_type = SongTag._getFrameType(key)
+        if frame_type == TagType.People:
+            return EditorType.PeopleValue
+        if key in SongTag.KEYS_ALLOW_MULTIPLE_VALUES:
+            return EditorType.MultipleText
+        return EditorType.SingleText
 
     @staticmethod
     def _getFrameType(id3_key: str) -> TagType:
@@ -146,6 +156,11 @@ class SongTag:
             logger.debug(f"KeyError from song for id3_key {self.id3_key}")
             return None
 
+    @property
+    def editor_type(self) -> EditorType:
+        """Stores the kind of widget that should be used for editing the values."""
+        return self._editor_type
+
     def setTag(self, song: ID3, values: SongGroupData) -> None:
         """Sets the tag for this song to contain the values that are sent."""
         if not self.hasTag(song):
@@ -187,12 +202,10 @@ class SongTag:
         song_data = self.getTag(song)
         if song_data is None:
             return None
-        match self.frame_type:
-            case TagType.People:
+        match self.editor_type:
+            case EditorType.PeopleValue:
                 return cast(SongTableData, song_data)
+            case EditorType.MultipleText:
+                return [str(val) for val in cast(SongListData, song_data)]
             case _:
-                # noinspection PyTypeHints
-                song_data = cast(SongLineData | SongListData, song_data)
-                if self.allow_multiple:
-                    return [str(val) for val in song_data]
-                return str(song_data[0])
+                return str(cast(SongLineData, song_data)[0])

--- a/src/music_modify/custom_types/tag_info.py
+++ b/src/music_modify/custom_types/tag_info.py
@@ -6,6 +6,8 @@ before it is converted to a `SongTag`.
 
 from dataclasses import KW_ONLY, dataclass
 
+from .enums import EditorType
+
 
 @dataclass
 class TagInfo:
@@ -22,3 +24,5 @@ class TagInfo:
     "The display name for the id3_key, in human-readable form."
     show_in_table: bool = False
     "Whether the tag should appear in the main files table, or not."
+    editor_type: EditorType = EditorType.Automatic
+    "The type of widget/display that should be used for editing a tag."

--- a/src/music_modify/gui/edit/bulk/dialog_edit_bulk.py
+++ b/src/music_modify/gui/edit/bulk/dialog_edit_bulk.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from music_modify.custom_types.enums import TagType
+from music_modify.custom_types.enums import EditorType
 from music_modify.gui.edit.dialog_edit_abstract import EditAbstractDialog
 from music_modify.gui.utils import createTab
 from music_modify.models.song_repository import SongRepository
@@ -136,48 +136,56 @@ class EditBulkDialog(EditAbstractDialog):
             in_all: bool = True
             for song in self.songs:
                 current_data = copy.deepcopy(tag.getValue(song.id3))
-                if tag.frame_type == TagType.People:
-                    people_values[tag] = addValues(
-                        cast(list[list[str]] | None, current_data),
-                        people_values.get(tag, []),
-                    )
-                    continue
-                if tag.allow_multiple:
-                    normal_values[tag] = _addMultiValues(
-                        cast(list[str] | None, current_data),
-                        normal_values.get(tag, set()),
-                    )
-                    continue
-                normal_values[tag], in_all = _addSingleValues(
-                    cast(str | None, current_data),
-                    normal_values.get(tag, set()),
-                    in_all=in_all,
-                )
+                match tag.editor_type:
+                    case EditorType.PeopleValue:
+                        people_values[tag] = addValues(
+                            cast(list[list[str]] | None, current_data),
+                            people_values.get(tag, []),
+                        )
+                    case EditorType.MultipleText:
+                        normal_values[tag] = _addMultiValues(
+                            cast(list[str] | None, current_data),
+                            normal_values.get(tag, set()),
+                        )
+                    case EditorType.SingleText:
+                        normal_values[tag], in_all = _addSingleValues(
+                            cast(str | None, current_data),
+                            normal_values.get(tag, set()),
+                            in_all=in_all,
+                        )
+                    case _:
+                        logger.warning(
+                            f"editor_type had an unsupported value: {tag.editor_type}"
+                        )
 
             # Create widgets and add to layouts
-            if tag.frame_type == TagType.People:
-                people_widget_layout.addWidget(
-                    EditBulkPeopleWidget(
-                        self,
-                        people_values.get(tag, []),
-                        tag,
-                    ),
-                )
-                continue
-            if tag.allow_multiple:
-                multi_widget_layout.addWidget(
-                    EditBulkMultipleWidget(self, normal_values.get(tag, set()), tag),
-                )
-                continue
-            simple_widget_form_layout.addRow(
-                tag.display_name,
-                EditBulkLineWidget(
-                    self,
-                    normal_values.get(tag, set()),
-                    tag,
-                    in_all=in_all,
-                ),
-            )
+            match tag.editor_type:
+                case EditorType.PeopleValue:
+                    people_widget_layout.addWidget(
+                        EditBulkPeopleWidget(
+                            self,
+                            people_values.get(tag, []),
+                            tag,
+                        ),
+                    )
+                case EditorType.MultipleText:
+                    multi_widget_layout.addWidget(
+                        EditBulkMultipleWidget(
+                            self, normal_values.get(tag, set()), tag
+                        ),
+                    )
+                case EditorType.SingleText:
+                    simple_widget_form_layout.addRow(
+                        tag.display_name,
+                        EditBulkLineWidget(
+                            self,
+                            normal_values.get(tag, set()),
+                            tag,
+                            in_all=in_all,
+                        ),
+                    )
+                case _:
+                    pass
 
         self.resize(600, 400)
 

--- a/src/music_modify/gui/edit/widget_edit_factory.py
+++ b/src/music_modify/gui/edit/widget_edit_factory.py
@@ -14,7 +14,7 @@ from music_modify.custom_types.aliases import (
     SongListData,
     SongTableData,
 )
-from music_modify.custom_types.enums import TagType
+from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.songtag import SongTag
 
 from .widget_edit_abstract import EditAbstractWidget
@@ -50,25 +50,23 @@ class EditWidgetFactory:
             tag: Holds the format that the data should take, and other information.
             data: The actual value that the tag currently stores.
         """
-        if tag.frame_type == TagType.People:
-            # Is a people tag, so table with current data
-            data = cast(
-                SongTableData | None,
-                copy.deepcopy(data) if data is not None else None,
-            )
-            return EditTableWidget(parent, data)
-        if tag.allow_multiple:
-            # Allow multiple is true, so list with current data
-
-            # Send a copy otherwise when checking if a value is changed,
-            # it will always be false, because it's comparing the two
-            # changed values
-            if isinstance(data, str):
-                data = [data]
-            data = cast(SongListData | None, data)
-            data = data.copy() if data is not None else None
-            return EditListWidget(parent, data)
-        # Only allows a single value, which can be a string, ID3TimeStamp or None.
-        # Show in LineEdit.
-        data = cast(str | None, data)
-        return EditLineWidget(parent, data)
+        match tag.editor_type:
+            case EditorType.PeopleValue:
+                data = cast(
+                    SongTableData | None,
+                    copy.deepcopy(data) if data is not None else None,
+                )
+                return EditTableWidget(parent, data)
+            case EditorType.MultipleText:
+                if isinstance(data, str):
+                    data = [data]
+                data = cast(SongListData | None, data)
+                data = data.copy() if data is not None else None
+                return EditListWidget(parent, data)
+            case EditorType.SingleText:
+                data = cast(str | None, data)
+                return EditLineWidget(parent, data)
+            case _:
+                raise ValueError(
+                    f"editor_type had an unsupported value: {tag.editor_type}"
+                )

--- a/src/music_modify/gui/prefs/delegate_editor_type.py
+++ b/src/music_modify/gui/prefs/delegate_editor_type.py
@@ -1,0 +1,58 @@
+"""Module that managed an EditorTypeDelegate.
+
+This delegate is used for displaying a QComboBox for EditorType for tags.
+"""
+
+from typing import cast, override
+
+from PySide6.QtCore import QAbstractItemModel, QModelIndex, QPersistentModelIndex, Qt
+from PySide6.QtWidgets import (
+    QComboBox,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QWidget,
+)
+
+from music_modify.custom_types.enums import EditorType
+
+
+class EditorTypeDelegate(QStyledItemDelegate):
+    """A delegate for the EditorType column that provides a QComboBox."""
+
+    @override
+    def createEditor(
+        self,
+        parent: QWidget,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
+        /,
+    ) -> QWidget:
+        """Creates the QComboBox editor for the EditorType column."""
+        editor = QComboBox(parent)
+        for editor_type in EditorType:
+            editor.addItem(editor_type.value)
+        return editor
+
+    @override
+    def setEditorData(
+        self, editor: QWidget, index: QModelIndex | QPersistentModelIndex, /
+    ) -> None:
+        combo_box = cast(QComboBox, editor)
+        current_editor_type: EditorType = index.data(Qt.ItemDataRole.EditRole)
+
+        for i in range(combo_box.count()):
+            if combo_box.itemText(i) == current_editor_type.value:
+                combo_box.setCurrentIndex(i)
+                break
+
+    @override
+    def setModelData(
+        self,
+        editor: QWidget,
+        model: QAbstractItemModel,
+        index: QModelIndex | QPersistentModelIndex,
+        /,
+    ) -> None:
+        combo_box = cast(QComboBox, editor)
+
+        model.setData(index, combo_box.currentText(), Qt.ItemDataRole.EditRole)

--- a/src/music_modify/gui/prefs/dialog_prefs_tag.py
+++ b/src/music_modify/gui/prefs/dialog_prefs_tag.py
@@ -19,8 +19,10 @@ from PySide6.QtWidgets import (
 
 from music_modify.custom_types.enums import RowDirection
 from music_modify.gui.mixins.row_operation_mixin import RowOperationMixin
+from music_modify.gui.prefs.delegate_editor_type import EditorTypeDelegate
 from music_modify.gui.utils import getSelectedRows
 from music_modify.models import TagModel
+from music_modify.models.tag_model import TAG_MODEL_COLUMNS
 from music_modify.prefs import prefs
 
 from .dialog_prefs_abstract import PrefsAbstractDialog
@@ -54,6 +56,11 @@ class PrefsTagDialog(PrefsAbstractDialog, RowOperationMixin):
         self.model: TagModel = TagModel(tags)
         self.tag_table.setModel(self.model)
         self.tag_table.resizeColumnsToContents()
+
+        editor_type_col_index = TAG_MODEL_COLUMNS.index("editor_type")
+        delegate = EditorTypeDelegate()
+        self.tag_table.setItemDelegateForColumn(editor_type_col_index, delegate)
+
         self.model.invalid_input.connect(self.showInvalidInputMessage)
 
     @override

--- a/src/music_modify/models/tag_model.py
+++ b/src/music_modify/models/tag_model.py
@@ -17,6 +17,7 @@ from PySide6.QtCore import (
 )
 
 from music_modify.custom_types import TagInfo, constants
+from music_modify.custom_types.enums import EditorType
 from music_modify.utils import tableHeader
 
 logger = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ class TagModel(QAbstractTableModel):
         return tableHeader(TAG_MODEL_COLUMNS[section])
 
     @override
-    def data(
+    def data(  # noqa: PLR0911
         self,
         index: QModelIndex | QPersistentModelIndex,
         role: Qt.ItemDataRole | int = Qt.ItemDataRole.DisplayRole,
@@ -95,6 +96,14 @@ class TagModel(QAbstractTableModel):
                 return ""
             return None
 
+        if field == "editor_type":
+            editor_type_enum = getattr(self._tags[row], field)
+            if role == Qt.ItemDataRole.DisplayRole:
+                return editor_type_enum.value
+            if role == Qt.ItemDataRole.EditRole:
+                return editor_type_enum
+            return None
+
         if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
             return getattr(self._tags[row], field)
 
@@ -113,7 +122,7 @@ class TagModel(QAbstractTableModel):
         return super().flags(index) | Qt.ItemFlag.ItemIsEditable
 
     @override
-    def setData(
+    def setData(  # noqa: PLR0911
         self,
         index: QModelIndex | QPersistentModelIndex,
         value: str | int,
@@ -153,6 +162,22 @@ class TagModel(QAbstractTableModel):
             # otherwise it's always false.
             self._tags[row].show_in_table = value == Qt.CheckState.Checked.value
             self.dataChanged.emit(index, index, [role])
+            return True
+
+        if field == "editor_type" and role == Qt.ItemDataRole.EditRole:
+            new_editor_type: EditorType | None = None
+            for et in EditorType:
+                if value == et.value:
+                    new_editor_type = et
+                    break
+
+            if new_editor_type is None:
+                logger.warning(f"Could not find EditorType for value: {value}")
+                return False
+
+            if getattr(self._tags[row], field) != new_editor_type:
+                setattr(self._tags[row], field, new_editor_type)
+                self.dataChanged.emit(index, index, [role])
             return True
 
         return False

--- a/src/music_modify/prefs/prefs.py
+++ b/src/music_modify/prefs/prefs.py
@@ -9,6 +9,7 @@ from typing import ClassVar, final
 
 from PySide6.QtCore import QSettings
 
+from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.songtag import SongTag
 from music_modify.custom_types.tag_info import TagInfo
 
@@ -97,50 +98,224 @@ class Settings:
         self._settings.setValue("Split/split_values_at", value)
 
     default_tags: ClassVar[list[TagInfo]] = [
-        TagInfo(display_name="Track", id3_key="TRCK", show_in_table=True),
-        TagInfo(display_name="Title", id3_key="TIT2", show_in_table=True),
-        TagInfo(display_name="Artist", id3_key="TPE1", show_in_table=True),
-        TagInfo(display_name="Album Artist", id3_key="TPE2", show_in_table=True),
-        TagInfo(display_name="Album", id3_key="TALB", show_in_table=True),
-        TagInfo(display_name="Composer", id3_key="TCOM", show_in_table=True),
-        TagInfo(display_name="Lyricist", id3_key="TEXT", show_in_table=True),
-        TagInfo(display_name="Language", id3_key="TLAN", show_in_table=True),
-        TagInfo(display_name="BPM", id3_key="TBPM", show_in_table=True),
-        TagInfo(display_name="Key", id3_key="TKEY", show_in_table=True),
-        TagInfo(display_name="Involved People", id3_key="TIPL", show_in_table=True),
-        TagInfo(display_name="Musician Credits", id3_key="TMCL", show_in_table=True),
-        TagInfo(display_name="Sort Composer", id3_key="TSOC"),
-        TagInfo(display_name="Conductor", id3_key="TPE3"),
-        TagInfo(display_name="Year", id3_key="TDRC"),
-        TagInfo(display_name="Original Album", id3_key="TOAL"),
-        TagInfo(display_name="Original Artist", id3_key="TOPE"),
-        TagInfo(display_name="Subtitle", id3_key="TIT3"),
-        TagInfo(display_name="Disc Number", id3_key="TPOS"),
-        TagInfo(display_name="Set Subtitle", id3_key="TSST"),
-        TagInfo(display_name="Sort Artist", id3_key="TSOP"),
-        TagInfo(display_name="Sort Album Artist", id3_key="TSO2"),
-        TagInfo(display_name="Genre", id3_key="TCON"),
-        TagInfo(display_name="Publisher", id3_key="TPUB"),
-        TagInfo(display_name="Mood", id3_key="TMOO"),
-        TagInfo(display_name="Display Composer", id3_key="TXXX:DISPLAY COMPOSER"),
-        TagInfo(display_name="Release Date", id3_key="TXXX:RELEASE DATE"),
-        TagInfo(display_name="Original Year", id3_key="TXXX:originalyear"),
-        TagInfo(display_name="Scrobble Title", id3_key="TXXX:SCROBBLE TITLE"),
-        TagInfo(display_name="Track Name", id3_key="TXXX:TRACK NAME"),
-        TagInfo(display_name="Song Type", id3_key="TXXX:SONG TYPE"),
-        TagInfo(display_name="Scrobble Album", id3_key="TXXX:SCROBBLE ALBUM"),
-        TagInfo(display_name="Album Name", id3_key="TXXX:ALBUM NAME"),
-        TagInfo(display_name="Album Type", id3_key="TXXX:ALBUM TYPE"),
-        TagInfo(display_name="Album Version", id3_key="TXXX:ALBUM VERSION"),
-        TagInfo(display_name="Scrobble Artist", id3_key="TXXX:SCROBBLE ARTIST"),
-        TagInfo(display_name="Artist Shown", id3_key="TXXX:ARTIST SHOWN"),
-        TagInfo(display_name="Display Artist", id3_key="TXXX:DISPLAY ARTIST"),
-        TagInfo(display_name="Label", id3_key="TXXX:LABEL"),
-        TagInfo(display_name="Performer", id3_key="TXXX:PERFORMER"),
-        TagInfo(display_name="Remixer", id3_key="TXXX:REMIXER"),
-        TagInfo(display_name="Occasion", id3_key="TXXX:OCCASION"),
-        TagInfo(display_name="Keywords", id3_key="TXXX:KEYWORDS"),
-        TagInfo(display_name="Tempo", id3_key="TXXX:TEMPO"),
+        TagInfo(
+            display_name="Track",
+            id3_key="TRCK",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Title",
+            id3_key="TIT2",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Artist",
+            id3_key="TPE1",
+            show_in_table=True,
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Album Artist",
+            id3_key="TPE2",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Album",
+            id3_key="TALB",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Composer",
+            id3_key="TCOM",
+            show_in_table=True,
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Lyricist",
+            id3_key="TEXT",
+            show_in_table=True,
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Language",
+            id3_key="TLAN",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="BPM",
+            id3_key="TBPM",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Key",
+            id3_key="TKEY",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Involved People",
+            id3_key="TIPL",
+            show_in_table=True,
+            editor_type=EditorType.PeopleValue,
+        ),
+        TagInfo(
+            display_name="Musician Credits",
+            id3_key="TMCL",
+            show_in_table=True,
+            editor_type=EditorType.PeopleValue,
+        ),
+        TagInfo(
+            display_name="Sort Composer",
+            id3_key="TSOC",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Conductor", id3_key="TPE3", editor_type=EditorType.SingleText
+        ),
+        TagInfo(display_name="Year", id3_key="TDRC", editor_type=EditorType.SingleText),
+        TagInfo(
+            display_name="Original Album",
+            id3_key="TOAL",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Original Artist",
+            id3_key="TOPE",
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Subtitle", id3_key="TIT3", editor_type=EditorType.SingleText
+        ),
+        TagInfo(
+            display_name="Disc Number",
+            id3_key="TPOS",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Set Subtitle",
+            id3_key="TSST",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Sort Artist",
+            id3_key="TSOP",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Sort Album Artist",
+            id3_key="TSO2",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Genre", id3_key="TCON", editor_type=EditorType.MultipleText
+        ),
+        TagInfo(
+            display_name="Publisher", id3_key="TPUB", editor_type=EditorType.SingleText
+        ),
+        TagInfo(
+            display_name="Mood", id3_key="TMOO", editor_type=EditorType.MultipleText
+        ),
+        TagInfo(
+            display_name="Display Composer",
+            id3_key="TXXX:DISPLAY COMPOSER",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Release Date",
+            id3_key="TXXX:RELEASE DATE",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Original Year",
+            id3_key="TXXX:originalyear",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Scrobble Title",
+            id3_key="TXXX:SCROBBLE TITLE",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Track Name",
+            id3_key="TXXX:TRACK NAME",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Song Type",
+            id3_key="TXXX:SONG TYPE",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Scrobble Album",
+            id3_key="TXXX:SCROBBLE ALBUM",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Album Name",
+            id3_key="TXXX:ALBUM NAME",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Album Type",
+            id3_key="TXXX:ALBUM TYPE",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Album Version",
+            id3_key="TXXX:ALBUM VERSION",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Scrobble Artist",
+            id3_key="TXXX:SCROBBLE ARTIST",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Artist Shown",
+            id3_key="TXXX:ARTIST SHOWN",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Display Artist",
+            id3_key="TXXX:DISPLAY ARTIST",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Label",
+            id3_key="TXXX:LABEL",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Performer",
+            id3_key="TXXX:PERFORMER",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Remixer",
+            id3_key="TXXX:REMIXER",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Occasion",
+            id3_key="TXXX:OCCASION",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Keywords",
+            id3_key="TXXX:KEYWORDS",
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Tempo",
+            id3_key="TXXX:TEMPO",
+            editor_type=EditorType.SingleText,
+        ),
     ]
     "Default values for known tags, if there are no user changes."
 
@@ -149,7 +324,11 @@ class Settings:
         """The tags shown in the main table."""
         if self._table_tags_cache is None:
             self._table_tags_cache = [
-                SongTag(display_name=tag.display_name, id3_key=tag.id3_key)
+                SongTag(
+                    display_name=tag.display_name,
+                    id3_key=tag.id3_key,
+                    editor_type=tag.editor_type,
+                )
                 for tag in self.info_tags
                 if tag.show_in_table
             ]
@@ -164,7 +343,11 @@ class Settings:
         using `TagInfo` objects.
         """
         return [
-            SongTag(display_name=tag.display_name, id3_key=tag.id3_key)
+            SongTag(
+                display_name=tag.display_name,
+                id3_key=tag.id3_key,
+                editor_type=tag.editor_type,
+            )
             for tag in self.info_tags
         ]
 
@@ -199,6 +382,7 @@ class Settings:
             self._settings.setValue("display_name", tag.display_name)
             self._settings.setValue("id3_key", tag.id3_key)
             self._settings.setValue("show_in_table", str(tag.show_in_table))
+            self._settings.setValue("editor_type", tag.editor_type.name)
         self._settings.endArray()
 
     def _getArray(self, key: str) -> list[TagInfo]:
@@ -214,11 +398,18 @@ class Settings:
             display_name: str = str(self._settings.value("display_name"))
             id3_key: str = str(self._settings.value("id3_key"))
             show_in_table: bool = self._settings.value("show_in_table") == "True"
+            editor_type_str: str = str(
+                self._settings.value("editor_type", EditorType.Automatic.name)
+            )
+            editor_type_enum: EditorType = getattr(
+                EditorType, editor_type_str, EditorType.Automatic
+            )
             tags.append(
                 TagInfo(
                     display_name=display_name,
                     id3_key=id3_key,
                     show_in_table=show_in_table,
+                    editor_type=editor_type_enum,
                 ),
             )
         self._settings.endArray()

--- a/tests/custom_types/test_songtag.py
+++ b/tests/custom_types/test_songtag.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_lazy_fixtures import lf
 
 from music_modify.custom_types import constants
-from music_modify.custom_types.enums import TagType
+from music_modify.custom_types.enums import EditorType, TagType
 from music_modify.custom_types.songtag import SongTag
 
 
@@ -34,19 +34,27 @@ def people_value() -> list[list[str]]:
 @pytest.fixture
 def single_tag() -> SongTag:
     """Fixture that returns a tag that stores a single value."""
-    return SongTag(id3_key="TIT2", display_name="Title")
+    return SongTag(
+        id3_key="TIT2", display_name="Title", editor_type=EditorType.SingleText
+    )
 
 
 @pytest.fixture
 def multiple_tag() -> SongTag:
     """Fixture that returns a tag that stores multiple values."""
-    return SongTag(id3_key="TCOM", display_name="Composer")
+    return SongTag(
+        id3_key="TCOM", display_name="Composer", editor_type=EditorType.MultipleText
+    )
 
 
 @pytest.fixture
 def people_tag() -> SongTag:
     """Fixture that returns a tag that stores people values."""
-    return SongTag(id3_key="TIPL", display_name="Involved People")
+    return SongTag(
+        id3_key="TIPL",
+        display_name="Involved People",
+        editor_type=EditorType.PeopleValue,
+    )
 
 
 @pytest.mark.parametrize(
@@ -65,6 +73,112 @@ def test_SongTag_id3_key(tag: SongTag, expected: str) -> None:
 def test_SongTag_display_name(tag: SongTag, expected: str) -> None:
     """Test that the display_name property gets set correctly."""
     assert tag.display_name == expected
+
+
+@pytest.mark.parametrize(
+    ("id3_key", "display_name", "editor_type", "expected"),
+    [
+        pytest.param(
+            "TIT2",
+            "Title",
+            None,
+            EditorType.SingleText,
+            id="single_no_editor_type_sent",
+        ),
+        pytest.param(
+            "TIT2",
+            "Title",
+            EditorType.Automatic,
+            EditorType.SingleText,
+            id="single_auto_editor_type_sent",
+        ),
+        pytest.param(
+            "TIT2",
+            "Title",
+            EditorType.SingleText,
+            EditorType.SingleText,
+            id="single_single_editor_type_sent",
+        ),
+        pytest.param(
+            "TIT2",
+            "Title",
+            EditorType.MultipleText,
+            EditorType.MultipleText,
+            id="single_multiple_editor_type_sent_overrides_default",
+        ),
+        pytest.param(
+            "TCOM",
+            "Composer",
+            None,
+            EditorType.MultipleText,
+            id="multiple_no_editor_type_sent",
+        ),
+        pytest.param(
+            "TCOM",
+            "Composer",
+            EditorType.Automatic,
+            EditorType.MultipleText,
+            id="multiple_auto_editor_type_sent",
+        ),
+        pytest.param(
+            "TCOM",
+            "Composer",
+            EditorType.MultipleText,
+            EditorType.MultipleText,
+            id="multiple_multiple_editor_type_sent",
+        ),
+        pytest.param(
+            "TCOM",
+            "Composer",
+            EditorType.SingleText,
+            EditorType.SingleText,
+            id="multiple_single_editor_type_sent_overrides_default",
+        ),
+        pytest.param(
+            "TIPL",
+            "Involved People",
+            None,
+            EditorType.PeopleValue,
+            id="people_no_editor_type_sent",
+        ),
+        pytest.param(
+            "TIPL",
+            "Involved People",
+            EditorType.Automatic,
+            EditorType.PeopleValue,
+            id="people_auto_editor_type_sent",
+        ),
+        pytest.param(
+            "TIPL",
+            "Involved People",
+            EditorType.PeopleValue,
+            EditorType.PeopleValue,
+            id="people_people_editor_type_sent",
+        ),
+        pytest.param(
+            "TIPL",
+            "Involved People",
+            EditorType.MultipleText,
+            EditorType.MultipleText,
+            id="people_multiple_editor_type_sent_overrides_default",
+        ),
+    ],
+)
+def test_SongTag_editor_type(
+    id3_key: str,
+    display_name: str,
+    editor_type: EditorType | None,
+    expected: EditorType,
+) -> None:
+    """Tests that editor_type property gets set correctly."""
+    if editor_type is None:
+        tag = SongTag(display_name=display_name, id3_key=id3_key)
+    else:
+        tag = SongTag(
+            display_name=display_name, id3_key=id3_key, editor_type=editor_type
+        )
+
+    assert tag.editor_type == expected
 
 
 @pytest.mark.parametrize(
@@ -93,19 +207,6 @@ def test_SongTag_display_name(tag: SongTag, expected: str) -> None:
 def test_SongTag_frame_type(tag: SongTag, expected: TagType) -> None:
     """Test that the frame_type property gets set correctly."""
     assert tag.frame_type == expected
-
-
-@pytest.mark.parametrize(
-    ("tag", "expected"),
-    [
-        pytest.param(lf("single_tag"), False, id="single_tag_False"),
-        pytest.param(lf("multiple_tag"), True, id="multiple_tag_True"),
-        pytest.param(lf("people_tag"), False, id="people_tag_False"),
-    ],
-)
-def test_SongTag_allow_multiple(tag: SongTag, expected: bool) -> None:
-    """Test that the allow_multiple property gets set correctly."""
-    assert tag.allow_multiple is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/gui/edit/bulk/test_dialog_edit_bulk.py
+++ b/tests/gui/edit/bulk/test_dialog_edit_bulk.py
@@ -2,14 +2,17 @@
 
 # pyright: reportPrivateUsage = false
 
+import logging
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from PySide6.QtWidgets import QWidget
 import pytest
 from pytestqt.qtbot import QtBot
 
+from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.song import Song
+from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.bulk.dialog_edit_bulk import (
     EditBulkDialog,
     _addMultiValues,
@@ -185,3 +188,35 @@ def test_EditBulkDialog_updateSongInfo_no_widgets(
 
     cast(Mock, song_1.save).assert_not_called()
     cast(Mock, song_2.save).assert_not_called()
+
+
+def test_EditBulkDialog_setupSongInfo_unsupported_editor_type_logged(
+    monkeypatch: pytest.MonkeyPatch, qtbot: QtBot, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that _setupSongInfo logs unsupported EditorType."""
+    widget = QWidget()
+    qtbot.addWidget(widget)
+
+    mock_repository = MagicMock(spec=SongRepository)
+    mock_song = MagicMock()
+    mock_song.id3 = "dummy_id3"
+    mock_repository.__getitem__.return_value = mock_song
+    rows = [0]
+
+    mock_tag = MagicMock(spec=SongTag)
+    mock_tag.editor_type = EditorType.Automatic
+    mock_tag.getValue.return_value = None
+    mock_tag.display_name = "Automatic Tag"
+
+    mock_prefs_settings = MagicMock()
+    mock_prefs_settings.all_tags = [mock_tag]
+    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_prefs_settings)
+
+    with caplog.at_level(logging.WARNING):
+        EditBulkDialog(widget, mock_repository, rows)
+
+        assert (
+            f"editor_type had an unsupported value: {EditorType.Automatic}"
+            in caplog.text
+        )
+        assert caplog.records[0].levelname == "WARNING"

--- a/tests/gui/edit/test_dialog_edit.py
+++ b/tests/gui/edit/test_dialog_edit.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QDialog, QWidget
 import pytest
 from pytestqt.qtbot import QtBot
 
-from music_modify.custom_types.enums import NavDirection
+from music_modify.custom_types.enums import EditorType, NavDirection
 from music_modify.custom_types.song import Song
 from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.dialog_edit import EditDialog
@@ -258,11 +258,13 @@ def test_EditDialog_resetSongInfo(
     mock_tag1.display_name = "Artist"
     mock_tag1.getValue.return_value = "Test Artist"
     mock_tag1.id3_key = "TPE1"
+    mock_tag1.editor_type = EditorType.MultipleText
 
     mock_tag2 = Mock(spec=SongTag)
     mock_tag2.display_name = "Title"
     mock_tag2.getValue.return_value = "Test Title"
     mock_tag2.id3_key = "TIT2"
+    mock_tag2.editor_type = EditorType.SingleText
 
     mock_all_tags = [mock_tag1, mock_tag2]
     mock_prefs_settings = Mock()

--- a/tests/gui/edit/test_widget_edit_factory.py
+++ b/tests/gui/edit/test_widget_edit_factory.py
@@ -1,9 +1,12 @@
 """Tests for EditWidgetFactory."""
 
+from unittest.mock import MagicMock
+
 from PySide6.QtWidgets import QWidget
 import pytest
 from pytestqt.qtbot import QtBot
 
+from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.widget_edit_factory import EditWidgetFactory
 from music_modify.gui.edit.widget_edit_line import EditLineWidget
@@ -16,21 +19,31 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
     [
         pytest.param(
             None,
-            SongTag(display_name="Title", id3_key="TIT2"),
+            SongTag(
+                display_name="Title", id3_key="TIT2", editor_type=EditorType.SingleText
+            ),
             "",
             EditLineWidget,
             id="line_tag_with_None",
         ),
         pytest.param(
             None,
-            SongTag(display_name="Composer", id3_key="TCOM"),
+            SongTag(
+                display_name="Composer",
+                id3_key="TCOM",
+                editor_type=EditorType.MultipleText,
+            ),
             [],
             EditListWidget,
             id="list_tag_with_None",
         ),
         pytest.param(
             None,
-            SongTag(display_name="Involved People", id3_key="TIPL"),
+            SongTag(
+                display_name="Involved People",
+                id3_key="TIPL",
+                editor_type=EditorType.PeopleValue,
+            ),
             [],
             EditTableWidget,
             id="people_tag_with_None",
@@ -40,53 +53,67 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
             SongTag(display_name="Title", id3_key="TIT2"),
             "",
             EditLineWidget,
-            id="line_tag_with_empty_value",
+            id="line_tag_auto_with_empty_value",
         ),
         pytest.param(
             [],
             SongTag(display_name="Composer", id3_key="TCOM"),
             [],
             EditListWidget,
-            id="list_tag_with_empty_value",
+            id="list_tag_auto_with_empty_value",
         ),
         pytest.param(
             [],
             SongTag(display_name="Involved People", id3_key="TIPL"),
             [],
             EditTableWidget,
-            id="people_tag_with_empty_value",
+            id="people_tag_auto_with_empty_value",
         ),
         pytest.param(
             "Name",
-            SongTag(display_name="Title", id3_key="TIT2"),
+            SongTag(
+                display_name="Title", id3_key="TIT2", editor_type=EditorType.SingleText
+            ),
             "",
             EditLineWidget,
             id="line_tag_with_value",
         ),
         pytest.param(
             ["First Name", "Second Name"],
-            SongTag(display_name="Composer", id3_key="TCOM"),
+            SongTag(
+                display_name="Composer",
+                id3_key="TCOM",
+                editor_type=EditorType.MultipleText,
+            ),
             [],
             EditListWidget,
             id="list_tag_with_multiple_values",
         ),
         pytest.param(
             ["First Name"],
-            SongTag(display_name="Composer", id3_key="TCOM"),
+            SongTag(
+                display_name="Composer",
+                id3_key="TCOM",
+                editor_type=EditorType.MultipleText,
+            ),
             [],
             EditListWidget,
             id="list_tag_with_single_value",
         ),
         pytest.param(
             [["role1", "Name 1"], ["role2", "Name 2"]],
-            SongTag(display_name="Involved People", id3_key="TIPL"),
+            SongTag(
+                display_name="Involved People",
+                id3_key="TIPL",
+                editor_type=EditorType.PeopleValue,
+            ),
             [],
             EditTableWidget,
             id="people_tag_with_value",
         ),
     ],
 )
-def test_EditWidgetFactory_create_type(
+def test_EditWidgetFactory_createWidget_normal(
     qtbot: QtBot,
     data: str | list[str] | list[list[str]] | None,
     tag: SongTag,
@@ -101,3 +128,17 @@ def test_EditWidgetFactory_create_type(
     qtbot.addWidget(created_widget)
     assert isinstance(created_widget, expected_type)
     assert created_widget.value == (data if data is not None else empty_data)
+
+
+def test_EditWidgetFactory_createWidget_unsupported_type_raises_error() -> None:
+    """Test createWidget raises ValueError when SongTag has unsupported EditorType."""
+    mock_parent = MagicMock(spec=QWidget)
+
+    mock_tag = MagicMock(spec=SongTag)
+    mock_tag.editor_type = EditorType.Automatic
+
+    with pytest.raises(
+        ValueError,
+        match=f"editor_type had an unsupported value: {EditorType.Automatic}",
+    ):
+        EditWidgetFactory.createWidget(mock_parent, mock_tag, None)

--- a/tests/gui/prefs/test_delegate_editor_type.py
+++ b/tests/gui/prefs/test_delegate_editor_type.py
@@ -1,0 +1,61 @@
+"""Tests for EditorTypeDelegate."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import QAbstractItemModel, QModelIndex, Qt
+from PySide6.QtWidgets import QComboBox, QStyleOptionViewItem, QWidget
+from pytestqt.qtbot import QtBot
+
+from music_modify.custom_types.enums import EditorType
+from music_modify.gui.prefs.delegate_editor_type import EditorTypeDelegate
+
+
+def test_EditorTypeDelegate_createEditor(qtbot: QtBot) -> None:
+    """Tests that a combo box is created for the delegate."""
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    delegate = EditorTypeDelegate()
+    editor = delegate.createEditor(widget, QStyleOptionViewItem(), QModelIndex())
+    assert isinstance(editor, QComboBox)
+    assert editor.count() == len(EditorType)
+    for i, editor_type in enumerate(EditorType):
+        assert editor.itemText(i) == editor_type.value
+
+
+def test_EditorTypeDelegate_setEditorData(qtbot: QtBot) -> None:
+    """Tests that setEditorData gets and sets the correct value."""
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    delegate = EditorTypeDelegate()
+
+    editor = delegate.createEditor(parent, QStyleOptionViewItem(), QModelIndex())
+
+    mock_index = MagicMock(spec=QModelIndex)
+    mock_index.data.return_value = EditorType.SingleText
+
+    delegate.setEditorData(editor, mock_index)
+
+    combo_box = cast(QComboBox, editor)
+    assert combo_box.currentText() == EditorType.SingleText.value
+
+
+def test_EditorTypeDelegate_setModelData() -> None:
+    """Tests that the model data gets set correctly when setModelData is called."""
+    delegate = EditorTypeDelegate()
+
+    mock_combo_box = MagicMock(spec=QComboBox)
+    selected_editor_type = EditorType.MultipleText.value
+    mock_combo_box.currentText.return_value = selected_editor_type
+
+    mock_model = MagicMock(spec=QAbstractItemModel)
+    mock_model.setData = MagicMock()
+
+    mock_index = MagicMock(spec=QModelIndex)
+
+    delegate.setModelData(mock_combo_box, mock_model, mock_index)
+
+    cast(MagicMock, mock_model.setData).assert_called_once_with(
+        mock_index, selected_editor_type, Qt.ItemDataRole.EditRole
+    )

--- a/tests/models/test_tag_model.py
+++ b/tests/models/test_tag_model.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import Qt
 import pytest
 
 from music_modify.custom_types import TagInfo
+from music_modify.custom_types.enums import EditorType
 from music_modify.models.tag_model import TAG_MODEL_COLUMNS, TagModel
 from music_modify.utils.string_utils import tableHeader
 
@@ -14,8 +15,18 @@ from music_modify.utils.string_utils import tableHeader
 def tags() -> list[TagInfo]:
     """Fixture that creates a list of TagInfo."""
     return [
-        TagInfo(id3_key="TIT2", display_name="Title", show_in_table=True),
-        TagInfo(id3_key="TPE2", display_name="Artist", show_in_table=False),
+        TagInfo(
+            id3_key="TIT2",
+            display_name="Title",
+            show_in_table=True,
+            editor_type=EditorType.Automatic,
+        ),
+        TagInfo(
+            id3_key="TPE2",
+            display_name="Artist",
+            show_in_table=False,
+            editor_type=EditorType.Automatic,
+        ),
     ]
 
 
@@ -94,13 +105,24 @@ def test_TagModel_data(model: TagModel, tags: list[TagInfo]) -> None:
             if field != "show_in_table"
             else Qt.ItemDataRole.CheckStateRole
         )
-        assert model.data(index, role) == (
-            getattr(tags[0], field)
-            if field != "show_in_table"
-            else Qt.CheckState.Checked
-        )
-    index = model.index(len(tags), 0)
-    assert model.data(index, Qt.ItemDataRole.DisplayRole) is None
+        actual_data = model.data(index, role)
+        if field == "show_in_table":
+            assert actual_data == Qt.CheckState.Checked
+        elif field == "editor_type":
+            assert actual_data == getattr(tags[0], field).value
+        else:
+            assert actual_data == getattr(tags[0], field)
+
+        edit_role = Qt.ItemDataRole.EditRole
+        if field != "show_in_table":
+            actual_edit_data = model.data(index, edit_role)
+            if field == "editor_type":
+                assert actual_edit_data == EditorType.Automatic
+            else:
+                assert actual_edit_data == getattr(tags[0], field)
+
+    invalid_index = model.index(len(tags), 0)
+    assert model.data(invalid_index, Qt.ItemDataRole.DisplayRole) is None
 
 
 def test_TagModel_setData(model: TagModel) -> None:
@@ -131,6 +153,28 @@ def test_TagModel_setData(model: TagModel) -> None:
         TagInfo(id3_key="TRCK", display_name="Title", show_in_table=False),
         TagInfo(id3_key="TPE2", display_name="Artist", show_in_table=False),
     ]
+
+    # Check setting editor_type
+    cols = [i for i, column in enumerate(TAG_MODEL_COLUMNS) if column == "editor_type"]
+    if len(cols) != 1:
+        pytest.fail("Zero or more than one columns found.")
+    editor_index = model.index(0, cols[0])
+    editor_val = EditorType.MultipleText.value
+    assert model.setData(editor_index, editor_val, Qt.ItemDataRole.EditRole)
+    assert model.tags[0] == TagInfo(
+        id3_key="TRCK",
+        display_name="Title",
+        show_in_table=False,
+        editor_type=EditorType.MultipleText,
+    )
+    invalid_val = "Invalid text"
+    assert model.setData(editor_index, invalid_val, Qt.ItemDataRole.EditRole) is False
+    assert model.tags[0] == TagInfo(
+        id3_key="TRCK",
+        display_name="Title",
+        show_in_table=False,
+        editor_type=EditorType.MultipleText,
+    )
 
     # Invalid index
     assert model.setData(model.index(-1, -1), 1) is False


### PR DESCRIPTION
Instead of doing multiple checks for frame_type and allows_multiple, add a property that indicates the actual widget that should be used. If it is not set in the constructor, it is calculated based on the old logic.

Also allows the user to set these values in preferences.