### PR TITLE
refactor(settings)!: Use QApplication info

### DIFF
--- a/src/music_modify/music_modify.py
+++ b/src/music_modify/music_modify.py
@@ -7,6 +7,7 @@ from typing import Never
 from PySide6.QtWidgets import QApplication
 
 from music_modify.gui import MainWindow
+from music_modify.prefs import prefs
 
 logging.basicConfig(
     level=logging.INFO,
@@ -22,6 +23,8 @@ def main() -> Never:
     app.setOrganizationName("Kayzels")
     app.setApplicationName("Music Modify")
     app.setApplicationVersion("2.0.0")
+
+    prefs.settings.configureForApplication()
 
     window = MainWindow()
     window.show()

--- a/src/music_modify/prefs/prefs.py
+++ b/src/music_modify/prefs/prefs.py
@@ -8,6 +8,7 @@ import logging
 from typing import ClassVar, final
 
 from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
 
 from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.songtag import SongTag
@@ -27,17 +28,42 @@ class Settings:
             new_settings: The settings values that should be read, if present.
         """
         logger.info("In init method for Settings object")
-        self._settings: QSettings = (
-            # PERF: Is there a way to get this from the QApplication,
-            # rather than setting it twice?
-            QSettings("Kayzels", "Music Modify")
-            if new_settings is None
-            else new_settings
-        )
+        self._settings: QSettings | None = None
 
         # Store in a cache to prevent needing to call getArray on every cell
         self._table_tags_cache: list[SongTag] | None = None
+
+        if new_settings is not None:
+            self._settings = new_settings
+            self._initializeDefaults()
+
+    def configureForApplication(self) -> None:
+        """Configure the QSettings object using info from the QApplication.
+
+        Uses the organization and application name from the QApplication instance.
+
+        This should only be called once the QApplication has been initialized.
+        """
+        if self._settings is not None:
+            logger.warning("QSettings already configured. Skipping re-configuration.")
+            return
+
+        app = QApplication.instance()
+        if app is None:
+            logger.error("Called configure when there was not a QApplication instance.")
+            return
+
+        self._settings = QSettings(app.organizationName(), app.applicationName())
         self._initializeDefaults()
+
+    def _getQSettings(self) -> QSettings:
+        """Returns insternal QSettings object, raising an error if not initialized."""
+        if self._settings is None:
+            raise RuntimeError(
+                "Settings have not been configured for the application. "
+                + "Call configureForApplication() after QApplication is initialized."
+            )
+        return self._settings
 
     default_split_text_entered = ","
     default_split_values_display = "; "
@@ -51,7 +77,7 @@ class Settings:
         John Smith, Jane Doe should be understood as two separate values.
         """
         return str(
-            self._settings.value(
+            self._getQSettings().value(
                 "Split/split_text_entered",
                 Settings.default_split_text_entered,
             ),
@@ -59,7 +85,7 @@ class Settings:
 
     @split_text_entered.setter
     def split_text_entered(self, value: str) -> None:
-        self._settings.setValue("Split/split_text_entered", value)
+        self._getQSettings().setValue("Split/split_text_entered", value)
 
     @property
     def split_values_display(self) -> str:
@@ -69,7 +95,7 @@ class Settings:
         John Smith\\Jane Doe
         """
         return str(
-            self._settings.value(
+            self._getQSettings().value(
                 "Split/split_values_display",
                 Settings.default_split_values_display,
             ),
@@ -77,7 +103,7 @@ class Settings:
 
     @split_values_display.setter
     def split_values_display(self, value: str) -> None:
-        self._settings.setValue("Split/split_values_display", value)
+        self._getQSettings().setValue("Split/split_values_display", value)
 
     @property
     def split_values_at(self) -> str:
@@ -87,7 +113,7 @@ class Settings:
         this should split it into separate values.
         """
         return str(
-            self._settings.value(
+            self._getQSettings().value(
                 "Split/split_values_at",
                 Settings.default_split_values_at,
             ),
@@ -95,7 +121,7 @@ class Settings:
 
     @split_values_at.setter
     def split_values_at(self, value: str) -> None:
-        self._settings.setValue("Split/split_values_at", value)
+        self._getQSettings().setValue("Split/split_values_at", value)
 
     default_tags: ClassVar[list[TagInfo]] = [
         TagInfo(
@@ -372,18 +398,20 @@ class Settings:
         """
         logger.info(f"Began creating array for {key} with {len(vals)} entries.")
 
-        self._settings.beginGroup(key)
-        self._settings.remove("")
-        self._settings.endGroup()
+        qsettings = self._getQSettings()
 
-        self._settings.beginWriteArray(key)
+        qsettings.beginGroup(key)
+        qsettings.remove("")
+        qsettings.endGroup()
+
+        qsettings.beginWriteArray(key)
         for index, tag in enumerate(vals):
-            self._settings.setArrayIndex(index)
-            self._settings.setValue("display_name", tag.display_name)
-            self._settings.setValue("id3_key", tag.id3_key)
-            self._settings.setValue("show_in_table", str(tag.show_in_table))
-            self._settings.setValue("editor_type", tag.editor_type.name)
-        self._settings.endArray()
+            qsettings.setArrayIndex(index)
+            qsettings.setValue("display_name", tag.display_name)
+            qsettings.setValue("id3_key", tag.id3_key)
+            qsettings.setValue("show_in_table", str(tag.show_in_table))
+            qsettings.setValue("editor_type", tag.editor_type.name)
+        qsettings.endArray()
 
     def _getArray(self, key: str) -> list[TagInfo]:
         """Convert the stored QSettings array into a Python list of tags.
@@ -391,15 +419,17 @@ class Settings:
         Args:
             key: The name of the array to read from settings.
         """
-        size = self._settings.beginReadArray(key)
+        qsettings = self._getQSettings()
+
+        size = qsettings.beginReadArray(key)
         tags: list[TagInfo] = []
         for i in range(size):
-            self._settings.setArrayIndex(i)
-            display_name: str = str(self._settings.value("display_name"))
-            id3_key: str = str(self._settings.value("id3_key"))
-            show_in_table: bool = self._settings.value("show_in_table") == "True"
+            qsettings.setArrayIndex(i)
+            display_name: str = str(qsettings.value("display_name"))
+            id3_key: str = str(qsettings.value("id3_key"))
+            show_in_table: bool = qsettings.value("show_in_table") == "True"
             editor_type_str: str = str(
-                self._settings.value("editor_type", EditorType.Automatic.name)
+                qsettings.value("editor_type", EditorType.Automatic.name)
             )
             editor_type_enum: EditorType = getattr(
                 EditorType, editor_type_str, EditorType.Automatic
@@ -412,33 +442,25 @@ class Settings:
                     editor_type=editor_type_enum,
                 ),
             )
-        self._settings.endArray()
+        qsettings.endArray()
         return tags
 
     def _initializeDefaults(self) -> None:
         """Set the default values for all settings, if they aren't already set."""
-        logger.info("Called initialise defaults")
-        if not self._settings.contains("Split/split_text_entered"):
+        qsettings = self._getQSettings()
+        if not qsettings.contains("Split/split_text_entered"):
             self.split_text_entered = Settings.default_split_text_entered
-        else:
-            logger.info("Split text entered already set")
-        if not self._settings.contains("Split/split_values_display"):
+        if not qsettings.contains("Split/split_values_display"):
             self.split_values_display = Settings.default_split_values_display
-        else:
-            logger.info("Split values display already set")
-        if not self._settings.contains("Split/split_values_at"):
+        if not qsettings.contains("Split/split_values_at"):
             self.split_values_at = Settings.default_split_values_at
-        else:
-            logger.info("Split values at already set")
 
-        size = self._settings.beginReadArray("Tags/info_tags")
-        self._settings.endArray()
+        size = qsettings.beginReadArray("Tags/info_tags")
+        qsettings.endArray()
 
-        if not self._settings.contains("Tags/info_tags") and size == 0:
+        if not qsettings.contains("Tags/info_tags") and size == 0:
             logger.info("Setting info tags")
             self.info_tags = Settings.default_tags
-        else:
-            logger.info("Info Tags already set")
 
     def resetSplit(self) -> None:
         """Reset the value for the split preferences back to default."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,15 @@ from os import PathLike
 from pathlib import Path
 import shutil
 import tempfile
+from unittest.mock import MagicMock
 
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 import pytest
 
+from music_modify.custom_types.enums import EditorType
+from music_modify.custom_types.songtag import SongTag
+from music_modify.custom_types.tag_info import TagInfo
 from music_modify.prefs.prefs import Settings
 
 NUM_TEMP_SONGS = 3
@@ -74,10 +78,80 @@ def temp_settings() -> Generator[Settings]:
 
 
 @pytest.fixture(scope="session")
-def app_info(qapp: QApplication) -> tuple[str, str]:
+def app_info(qapp: QApplication) -> tuple[str, str, str]:
     """Fixture that creates dummy values for app name and version."""
+    org = "Test Kayzels"
     name = "Test Music Modify"
     version = "9.9.9"
+    qapp.setOrganizationName(org)
     qapp.setApplicationName(name)
     qapp.setApplicationVersion(version)
-    return (name, version)
+    return (org, name, version)
+
+
+@pytest.fixture
+def mock_settings(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Fixture that mocks the values for prefs.settings."""
+    mock_settings = MagicMock()
+    mock_default_tag_info = [
+        TagInfo(
+            display_name="Track",
+            id3_key="TRCK",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Title",
+            id3_key="TIT2",
+            show_in_table=True,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Artist",
+            id3_key="TPE1",
+            show_in_table=True,
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Album Artist",
+            id3_key="TPE2",
+            show_in_table=False,
+            editor_type=EditorType.SingleText,
+        ),
+        TagInfo(
+            display_name="Genre",
+            id3_key="TCON",
+            show_in_table=False,
+            editor_type=EditorType.MultipleText,
+        ),
+        TagInfo(
+            display_name="Involved People",
+            id3_key="TIPL",
+            show_in_table=True,
+            editor_type=EditorType.PeopleValue,
+        ),
+    ]
+
+    mock_table_tags_list = [
+        SongTag(
+            display_name=ti.display_name, id3_key=ti.id3_key, editor_type=ti.editor_type
+        )
+        for ti in mock_default_tag_info
+        if ti.show_in_table
+    ]
+    mock_settings.table_tags = mock_table_tags_list
+
+    mock_all_tags_list = [
+        SongTag(
+            display_name=ti.display_name, id3_key=ti.id3_key, editor_type=ti.editor_type
+        )
+        for ti in mock_default_tag_info
+    ]
+    mock_settings.all_tags = mock_all_tags_list
+
+    mock_settings.split_values_display = "; "
+    mock_settings.split_text_entered = ","
+
+    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_settings)
+
+    return mock_settings

--- a/tests/custom_types/test_song.py
+++ b/tests/custom_types/test_song.py
@@ -1,5 +1,7 @@
 """Tests for Song."""
 
+# pyright: reportUnusedParameter = false
+
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -13,15 +15,15 @@ from music_modify.prefs import prefs
 logger = logging.getLogger(__name__)
 
 
-def test_Song_init_with_None() -> None:
+def test_Song_init_with_None(mock_settings: MagicMock) -> None:
     """Test that a Song object is created correctly when not passed a file."""
     song = Song()
     assert song.file is None
-    info: list[str] = ["" for _ in range(len(prefs.settings.table_tags))]
+    info: list[str] = ["" for _ in range(len(mock_settings.table_tags))]
     assert song.display_info == info
 
 
-def test_Song_init_with_file(song_path: Path) -> None:
+def test_Song_init_with_file(song_path: Path, mock_settings: MagicMock) -> None:
     """Test that a Song object is created correctly when passed a file."""
     song = Song(song_path)
     assert song.file == song_path
@@ -29,7 +31,9 @@ def test_Song_init_with_file(song_path: Path) -> None:
     assert isinstance(song.display_info, list)
 
 
-def test_Song_columns_setTag_removeTag(song_path: Path) -> None:
+def test_Song_columns_setTag_removeTag(
+    song_path: Path, mock_settings: MagicMock
+) -> None:
     """Test that setting and then removing tags works."""
     song = Song(song_path)
     song.setTag("TIT2", ["Some Title"])
@@ -54,7 +58,9 @@ def test_Song_columns_setTag_removeTag(song_path: Path) -> None:
     assert not song.hasTag("TPE2")
 
 
-def test_Song_invalid_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_Song_invalid_tag(
+    monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+) -> None:
     """Test that invalid tags work correctly.
 
     They should return False for hasTag, None for getValue, and don't call removeTag.
@@ -72,7 +78,7 @@ def test_Song_invalid_tag(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_Song_save_calls_updateInfo(
-    song_path: Path, monkeypatch: pytest.MonkeyPatch
+    song_path: Path, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Test that saving a song updates the file and the displayed info."""
     song = Song(song_path)
@@ -89,7 +95,9 @@ def test_Song_save_calls_updateInfo(
     mock_update.assert_called_once()
 
 
-def test_Song_save_calls_updateInfo_file_None(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_Song_save_calls_updateInfo_file_None(
+    monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+) -> None:
     """Test that saving a song updates the displayed info, but doesn't save a file."""
     song = Song()
     song.setTag("TIT2", ["Some Title"])
@@ -105,7 +113,7 @@ def test_Song_save_calls_updateInfo_file_None(monkeypatch: pytest.MonkeyPatch) -
     mock_update.assert_called_once()
 
 
-def test_Song_load(song_path: Path) -> None:
+def test_Song_load(song_path: Path, mock_settings: MagicMock) -> None:
     """Test that creating a song and loading the file later still populates data."""
     song = Song()
     assert song.file is None

--- a/tests/gui/about/test_dialog_about.py
+++ b/tests/gui/about/test_dialog_about.py
@@ -34,10 +34,10 @@ def test_AboutDialog_generateText_no_instance(
 
 def test_AboutDialog_generateText_valid_instance(
     monkeypatch: pytest.MonkeyPatch,
-    app_info: tuple[str, str],
+    app_info: tuple[str, str, str],
 ) -> None:
     """Test that generateText creates the correct HTML when app info is valid."""
-    mock_app_name, mock_app_version = app_info
+    _, mock_app_name, mock_app_version = app_info
     mock_python_version = "3.10.0"
     mock_pyside_version = "6.5.0"
     mock_mutagen_version = "1.50"

--- a/tests/gui/completion/test_complete_line_edit.py
+++ b/tests/gui/completion/test_complete_line_edit.py
@@ -1,5 +1,7 @@
 """Tests EnLineEdit."""
 
+# pyright: reportUnusedParameter = false
+
 from typing import cast
 from unittest.mock import MagicMock, Mock
 
@@ -279,7 +281,7 @@ def test_EnLineEdit_updateCompletions_singleMode(qtbot: QtBot) -> None:
 
 
 def test_EnLineEdit_updateCompletions_multipleMode_withSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Test that multiple mode adds separators after the items."""
     line_edit = EnLineEdit(multiple=True)
@@ -300,7 +302,7 @@ def test_EnLineEdit_updateCompletions_multipleMode_withSeparator(
 
 
 def test_EnLineEdit_updateCompletions_multipleMode_noSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Test that multiple mode doesn't add a separator when there is only one item."""
     line_edit = EnLineEdit(multiple=True)
@@ -320,7 +322,9 @@ def test_EnLineEdit_updateCompletions_multipleMode_noSeparator(
     line_edit.mcompleter.setCompletionPrefix.assert_called_once_with("just_one_item")
 
 
-def test_EnLineEdit_updateCompletions_emptyText(qtbot: QtBot) -> None:
+def test_EnLineEdit_updateCompletions_emptyText(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests updating completions with empty text."""
     line_edit = EnLineEdit()
     qtbot.addWidget(line_edit)
@@ -337,7 +341,7 @@ def test_EnLineEdit_updateCompletions_emptyText(qtbot: QtBot) -> None:
 
 
 def test_EnLineEdit_updateCompletions_cursorInMiddle(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that completions are added when updating and the cursor is in the middle.
 
@@ -372,7 +376,7 @@ def test_EnLineEdit_getCompletedText_singleMode(qtbot: QtBot) -> None:
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_emptyLineEdit(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that selecting the first entry in multiple mode adds a separator after."""
     line_edit = EnLineEdit(multiple=True)
@@ -390,7 +394,7 @@ def test_EnLineEdit_getCompletedText_multipleMode_emptyLineEdit(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_noOriginalCursorPos(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that cursorPosition is used if there is no original cursor position."""
     line_edit = EnLineEdit(multiple=True)
@@ -411,7 +415,7 @@ def test_EnLineEdit_getCompletedText_multipleMode_noOriginalCursorPos(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_withOriginalCursorPos(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that the original cursor position is used if it exists."""
     line_edit = EnLineEdit(multiple=True)
@@ -432,7 +436,7 @@ def test_EnLineEdit_getCompletedText_multipleMode_withOriginalCursorPos(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_cursorAtEnd(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that an item is appened when the cursor is at the end.
 
@@ -453,7 +457,7 @@ def test_EnLineEdit_getCompletedText_multipleMode_cursorAtEnd(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_cursorAtStart(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that adding an item at the start adds it.
 
@@ -577,7 +581,7 @@ def test_EnLineEdit_applyCurrentText_singleMode(qtbot: QtBot) -> None:
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_withSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests applying text in multiple mode when an item is selected after a separator.
 
@@ -600,7 +604,7 @@ def test_EnLineEdit_applyCurrentText_multipleMode_withSeparator(
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_noSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests applying the text when there is a single item with no separator.
 
@@ -626,7 +630,7 @@ def test_EnLineEdit_applyCurrentText_multipleMode_noSeparator(
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_emptyText(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests applying the text when there are no items, only empty text."""
     line_edit = EnLineEdit(multiple=True)
@@ -647,7 +651,7 @@ def test_EnLineEdit_applyCurrentText_multipleMode_emptyText(
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_separatorAtStart(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests applying current text when cursor is right after separator.
 

--- a/tests/gui/edit/bulk/test_dialog_edit_bulk.py
+++ b/tests/gui/edit/bulk/test_dialog_edit_bulk.py
@@ -1,6 +1,6 @@
 """Tests for EditBulkDialog."""
 
-# pyright: reportPrivateUsage = false
+# pyright: reportPrivateUsage = false, reportUnusedParameter = false
 
 import logging
 from typing import cast
@@ -36,7 +36,7 @@ def test_addSingleValues() -> None:
 
 
 def test_EditBulkDialog_updateSongInfo_no_changes(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that save is not called if no changes were made to the song."""
     parent = QWidget()
@@ -75,7 +75,7 @@ def test_EditBulkDialog_updateSongInfo_no_changes(
 
 
 def test_EditBulkDialog_updateSongInfo_with_changes(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Test that save is called with the updated changes."""
     parent = QWidget()
@@ -117,7 +117,7 @@ def test_EditBulkDialog_updateSongInfo_with_changes(
 
 
 def test_EditBulkDialog_updateSongInfo_with_changes_single(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Test that save is only called for songs that actually change data."""
     parent = QWidget()
@@ -159,7 +159,7 @@ def test_EditBulkDialog_updateSongInfo_with_changes_single(
 
 
 def test_EditBulkDialog_updateSongInfo_no_widgets(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that save is not called, without mocking widgets."""
     parent = QWidget()

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_line.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_line.py
@@ -1,5 +1,9 @@
 """Tests for EditBulkLineWidget."""
 
+# pyright: reportUnusedParameter = false
+
+from unittest.mock import MagicMock
+
 from PySide6.QtWidgets import QWidget
 from pytestqt.qtbot import QtBot
 
@@ -120,7 +124,9 @@ def test_EditBulkLineWidget_updateTag_clear_no_songs(qtbot: QtBot) -> None:
     assert not widget.updateTag([])
 
 
-def test_EditBulkLineWidget_updateTag_apply_empty_clears(qtbot: QtBot) -> None:
+def test_EditBulkLineWidget_updateTag_apply_empty_clears(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that updateTag clears the tag if apply is called with an empty widget."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -136,7 +142,9 @@ def test_EditBulkLineWidget_updateTag_apply_empty_clears(qtbot: QtBot) -> None:
     assert song.hasTag(tag) is False
 
 
-def test_EditBulkLineWidget_updateTag_apply_only_space_clears(qtbot: QtBot) -> None:
+def test_EditBulkLineWidget_updateTag_apply_only_space_clears(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that updateTag clears tag if apply called with widget having only space."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -152,7 +160,9 @@ def test_EditBulkLineWidget_updateTag_apply_only_space_clears(qtbot: QtBot) -> N
     assert song.hasTag(tag) is False
 
 
-def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(qtbot: QtBot) -> None:
+def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that calling update when not empty sets the tag value."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -174,7 +184,7 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(qtbot: QtBot) -> None
 
 
 def test_EditBulkLineWidget_updateTag_apply_not_empty_sets_stripped(
-    qtbot: QtBot,
+    qtbot: QtBot, mock_settings: MagicMock
 ) -> None:
     """Test that calling update when not empty sets the tag value without whitespace."""
     _, tag, widget = _createWidget(qtbot)
@@ -196,7 +206,9 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets_stripped(
     assert widget.main_widget.text() == new_value.strip()
 
 
-def test_EditBulkLineWidget_updateTag_clear(qtbot: QtBot) -> None:
+def test_EditBulkLineWidget_updateTag_clear(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that clearing works when clear checkbox checked and updating."""
     _, tag, widget = _createWidget(qtbot)
 

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_multiple.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_multiple.py
@@ -1,9 +1,9 @@
 """Tests for EditBulkMultipleWidget."""
 
-# pyright: reportPrivateUsage = false
+# pyright: reportPrivateUsage = false, reportUnusedParameter = false
 
 from typing import NotRequired, TypedDict
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from PySide6.QtWidgets import QWidget
 import pytest
@@ -73,7 +73,9 @@ def test_EditBulkMultipleWidget_updateTag_group_box_unchecked(
     assert not widget.updateTag(songs)
 
 
-def test_EditBulkMultipleWidget_adds_to_line(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_adds_to_line(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests typing a value in the lines updates line values, but not widget ones.
 
     The widget should only store the values actually stored in all the songs.
@@ -90,7 +92,9 @@ def test_EditBulkMultipleWidget_adds_to_line(qtbot: QtBot) -> None:
     assert widget.items == ("One",)
 
 
-def test_EditBulkMultipleWidget_updateTag_clear_checkbox_checked(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_clear_checkbox_checked(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests that tags are removed if updateTag is called with clear checked."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -109,7 +113,9 @@ def test_EditBulkMultipleWidget_updateTag_clear_checkbox_checked(qtbot: QtBot) -
     assert not song2.hasTag(tag)
 
 
-def test_EditBulkMultipleWidget_updateTag_empty_add_empty_remove(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_empty_add_empty_remove(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests adding or removing empty values doesn't change the song value."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -132,7 +138,9 @@ def test_EditBulkMultipleWidget_updateTag_empty_add_empty_remove(qtbot: QtBot) -
     assert song2.getValue(tag) == ["One Composer", "Another Composer"]
 
 
-def test_EditBulkMultipleWidget_updateTag_single_song_empty_add(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_single_song_empty_add(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests adding values to a song that doesn't have the tag at start."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -156,7 +164,7 @@ def test_EditBulkMultipleWidget_updateTag_single_song_empty_add(qtbot: QtBot) ->
 
 
 def test_EditBulkMultipleWidget_updateTag_single_song_and_widget_same(
-    qtbot: QtBot,
+    qtbot: QtBot, mock_settings: MagicMock
 ) -> None:
     """Tests that setting text for adding a value already present doesn't add it."""
     _, tag, widget = _createWidget(qtbot)
@@ -176,7 +184,9 @@ def test_EditBulkMultipleWidget_updateTag_single_song_and_widget_same(
     assert song.getValue(tag) == ["Some Name", "And Another"]
 
 
-def test_EditBulkMultipleWidget_updateTag_single_widget_has_extra(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_single_widget_has_extra(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests that any items not in the song are correctly added.
 
     Tests that the items that are already present aren't added again,
@@ -257,6 +267,7 @@ def test_EditBulkMultipleWidget_updateTag_songs_param(
     value: list[str] | None,
     expected_updated: bool,
     expected_value: list[str],
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that updateTag changes values that it should."""
     _, tag, widget = _createWidget(qtbot)
@@ -277,7 +288,9 @@ def test_EditBulkMultipleWidget_updateTag_songs_param(
     assert song.getValue(tag) == expected_value
 
 
-def test_EditBulkMultipleWidget_updateTag_multiple_add(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_multiple_add(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests adding values to multiple songs, with different conditions."""
     _, tag, widget = _createWidget(qtbot)
 
@@ -303,7 +316,9 @@ def test_EditBulkMultipleWidget_updateTag_multiple_add(qtbot: QtBot) -> None:
         assert song.getValue(tag) == expected_final_values[i]
 
 
-def test_EditBulkMultipleWidget_updateTag_song_empty_remove(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_updateTag_song_empty_remove(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests that removing tag values for songs that don't have that tag works.
 
     The tag shouldn't be added, and updateTag should return an empty set.
@@ -379,6 +394,7 @@ def test_EditBulkMultipleWidget_updateTag_remove_param(
     widget_text: str,
     expected_updated: bool,
     expected_final_value: list[str],
+    mock_settings: MagicMock,
 ) -> None:
     """Tests removing tag values in different conditions.
 
@@ -404,7 +420,7 @@ def test_EditBulkMultipleWidget_updateTag_remove_param(
 
 
 def test_EditBulkMultipleWidget_updateTag_add_remove(
-    qtbot: QtBot,
+    qtbot: QtBot, mock_settings: MagicMock
 ) -> None:
     """Tests that both adding and removing values works if done together.
 
@@ -427,7 +443,9 @@ def test_EditBulkMultipleWidget_updateTag_add_remove(
     assert song.getValue(tag) == ["Extra Value", "New Value", "And Another"]
 
 
-def test_EditBulkMultipleWidget_resetView(qtbot: QtBot) -> None:
+def test_EditBulkMultipleWidget_resetView(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that resetView restores the original state for the widget."""
     _, tag, widget = _createWidget(qtbot, set())
 

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_people.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_people.py
@@ -1,6 +1,6 @@
 """Tests for EditBulkPeopleWidget."""
 
-# pyright: reportPrivateUsage = false
+# pyright: reportPrivateUsage = false, reportUnusedParameter = false
 
 from typing import TypedDict, cast
 from unittest.mock import MagicMock
@@ -131,7 +131,7 @@ change_params: list[_ChangeParams] = [
     ],
 )
 def test_ActionMapping_performChange_param(
-    qtbot: QtBot, change_param: _ChangeParams
+    qtbot: QtBot, change_param: _ChangeParams, mock_settings: MagicMock
 ) -> None:
     """Tests how performChange works based on different inputs.
 
@@ -245,7 +245,9 @@ def test_EditBulkPeopleWidget_updateTag_unchecked(qtbot: QtBot) -> None:
     assert widget.updateTag(songs) == set()
 
 
-def test_EditBulkPeopleWidget_updateTag_clear_checkbox_checked(qtbot: QtBot) -> None:
+def test_EditBulkPeopleWidget_updateTag_clear_checkbox_checked(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Test that values are cleared when updateTag is called with clear checked."""
     initial_data = [["Role 1", "Person 1"]]
     _, tag, widget = _createWidget(qtbot, initial_data)
@@ -268,7 +270,9 @@ def test_EditBulkPeopleWidget_updateTag_clear_checkbox_checked(qtbot: QtBot) -> 
     assert song2.getValue(tag) is None
 
 
-def test_EditBulkPeopleWidget_updateTag_no_changes_attempted(qtbot: QtBot) -> None:
+def test_EditBulkPeopleWidget_updateTag_no_changes_attempted(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests that updateTag isn't called when there are no changes."""
     widget_data = []
     _, tag, widget = _createWidget(qtbot, widget_data)
@@ -531,6 +535,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_param(
     widget_name: str,
     widget_items: list[str] | list[list[str]],
     song_infos: list[_SongInfo],
+    mock_settings: MagicMock,
 ) -> None:
     """Test updating tag based on the widget details."""
     widget_data = []
@@ -573,6 +578,7 @@ def test_EditBulkPeopleWidget_updateTag_single_param(
     widget_name: str,
     widget_items: list[str] | list[list[str]],
     info: _SongInfo,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests updating tags for a single song, based on the widget details."""
     widget_data = []
@@ -595,7 +601,9 @@ def test_EditBulkPeopleWidget_updateTag_single_param(
     assert song.getValue(tag) == info["expected_items"]
 
 
-def test_EditBulkPeopleWidget_updateTag_multiple_actions(qtbot: QtBot) -> None:
+def test_EditBulkPeopleWidget_updateTag_multiple_actions(
+    qtbot: QtBot, mock_settings: MagicMock
+) -> None:
     """Tests calling updateTag with multiple fields filled."""
     initial_widget_items = [
         ["ExistingRole", "ExistingPerson"],
@@ -654,7 +662,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_actions(qtbot: QtBot) -> None:
 
 
 def test_EditBulkPeopleWidget_resetView(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that the people widget re-displays the original values on reset."""
     initial_widget_data = [["Role1", "Person1"], ["Role2", "Person2"]]

--- a/tests/gui/edit/test_dialog_edit.py
+++ b/tests/gui/edit/test_dialog_edit.py
@@ -1,10 +1,10 @@
 """Tests for EditDialog."""
 
-# pyright: reportPrivateUsage = false
+# pyright: reportPrivateUsage = false, reportUnusedParameter = false
 
 import logging
 from typing import cast
-from unittest.mock import Mock, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 from PySide6.QtWidgets import QDialog, QWidget
 import pytest
@@ -49,7 +49,7 @@ def test_EditDialog_init_song_None(qtbot: QtBot) -> None:
     assert dialog.result() == QDialog.DialogCode.Rejected
 
 
-def test_EditDialog_init_song_single(qtbot: QtBot) -> None:
+def test_EditDialog_init_song_single(qtbot: QtBot, mock_settings: MagicMock) -> None:
     """Tests that the song is found at the index, and nav buttons aren't created."""
     _, dialog = _createDialog(qtbot, [0], num_songs=1)
 
@@ -60,7 +60,7 @@ def test_EditDialog_init_song_single(qtbot: QtBot) -> None:
     assert not hasattr(dialog, "next_button")
 
 
-def test_EditDialog_init_song_multiple(qtbot: QtBot) -> None:
+def test_EditDialog_init_song_multiple(qtbot: QtBot, mock_settings: MagicMock) -> None:
     """Tests that the songs are found at the indexes, and nav buttons are created."""
     _, dialog = _createDialog(qtbot, [0, 1], num_songs=2)
 
@@ -92,7 +92,7 @@ def test_EditDialog_init_song_multiple(qtbot: QtBot) -> None:
 
 
 def test_EditDialog_updateSongInfo_setsValue(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that calling updateSongInfo saves the values to the song."""
     _, dialog = _createDialog(qtbot, [0], num_songs=1)
@@ -123,7 +123,7 @@ def test_EditDialog_updateSongInfo_setsValue(
 
 
 def test_EditDialog_updateSongInfo_removesValue(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that calling updateSongInfo removes values when needed."""
     _, dialog = _createDialog(qtbot, [0], num_songs=1)
@@ -154,7 +154,10 @@ def test_EditDialog_updateSongInfo_removesValue(
 
 
 def test_EditDialog_updateSongInfo_unknownTag(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that updating an unknown tag logs, and doesn't save."""
     _, dialog = _createDialog(qtbot, [0], num_songs=1)
@@ -207,7 +210,7 @@ def test_EditDialog_switchButtonState_no_buttons_logged(
 
 
 def test_EditDialog_showSongInDirection_last_or_first_logged(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture, mock_settings: MagicMock
 ) -> None:
     """Tests that invalid navigation on first or last is logged."""
     _, dialog = _createDialog(qtbot, [0, 1], num_songs=2)
@@ -235,7 +238,7 @@ def test_EditDialog_showSongInDirection_last_or_first_logged(
 
 
 def test_EditDialog_showSongInDirection_no_song(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture, mock_settings: MagicMock
 ) -> None:
     """Tests that trying to display a song at an invalid index closes the dialog."""
     _, dialog = _createDialog(qtbot, [0, 1], num_songs=1)
@@ -248,7 +251,7 @@ def test_EditDialog_showSongInDirection_no_song(
 
 
 def test_EditDialog_resetSongInfo(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> None:
     """Tests that the song values can be reset."""
     widget, repo = _createParentAndRepo(qtbot, 1)
@@ -288,7 +291,7 @@ def test_EditDialog_resetSongInfo(
 
 @pytest.fixture
 def edit_dialog_mocks(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
 ) -> tuple[EditDialog, Mock, Mock, PropertyMock]:
     """Fixture for creating multiple mocks for EditDialogs."""
     _, dialog = _createDialog(qtbot, [0], num_songs=1)

--- a/tests/gui/main/test_gui_main.py
+++ b/tests/gui/main/test_gui_main.py
@@ -1,5 +1,7 @@
 """Tests for MainWindow."""
 
+# pyright: reportUnusedParameter = false
+
 import logging
 import os
 from os import PathLike
@@ -33,6 +35,7 @@ def test_MainWindow_addFiles(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Test that addFiles correctly adds the files to the model."""
     window = MainWindow()
@@ -45,6 +48,7 @@ def test_MainWindow_clearFiles(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Test that clearFiles removes the songs from the model."""
     window = MainWindow()
@@ -59,6 +63,7 @@ def test_MainWindow_clearFiles_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Test that calling the clearFiles action clears the files."""
     window = MainWindow()
@@ -73,6 +78,7 @@ def test_MainWindow_setFileActionState(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Test that the state of actions changes based on there being files or not."""
     window = MainWindow()
@@ -87,7 +93,7 @@ def test_MainWindow_setFileActionState(
 
 
 def test_MainWindow_setSelectionActionState(
-    qtbot: QtBot, song_paths: list[PathLike[str]]
+    qtbot: QtBot, song_paths: list[PathLike[str]], mock_settings: MagicMock
 ) -> None:
     """Test that the state of actions changes based on there being a selection."""
     window = MainWindow()
@@ -109,6 +115,7 @@ def test_MainWindow_selectAll_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that calling the select all action selects all songs."""
     window = MainWindow()
@@ -123,6 +130,7 @@ def test_MainWindow_selectNone_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that calling the select none action clears the selection."""
     window = MainWindow()
@@ -139,6 +147,7 @@ def test_MainWindow_removeSelectedFiles_normal(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that selected files are removed when there is a selection."""
     window = MainWindow()
@@ -158,6 +167,7 @@ def test_MainWindow_removeSelectedFiles_none_selected(
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
     caplog: pytest.LogCaptureFixture,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that removing files with none selection creates a log message."""
     window = MainWindow()
@@ -185,6 +195,7 @@ def test_MainWindow_removeSelectedFiles_all_selected(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that clearFiles is called if removeSelected is called with all selected."""
     window = MainWindow()
@@ -209,6 +220,7 @@ def test_MainWindow_removeSelectedFiles_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that the action for remove selected triggers the correct change."""
     window = MainWindow()
@@ -227,6 +239,7 @@ def test_MainWindow_updateStatusbarMessage(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
+    mock_settings: MagicMock,
 ) -> None:
     """Tests that the statusbar values are updated based on state."""
     window = MainWindow()

--- a/tests/models/test_song_models.py
+++ b/tests/models/test_song_models.py
@@ -1,12 +1,14 @@
 """Tests for SongModel."""
 
+# pyright: reportUnusedParameter = false
+
 from os import PathLike
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from PySide6.QtCore import Qt
 
 from music_modify.models import SongRepository, SongTableModel
-from music_modify.prefs import prefs
 
 
 def test_SongTableModel_init() -> None:
@@ -25,13 +27,13 @@ def test_SongTableModel_init() -> None:
     )
 
 
-def test_SongTableModel_songs_added(song_path: Path) -> None:
+def test_SongTableModel_songs_added(song_path: Path, mock_settings: MagicMock) -> None:
     """Test that the model is updated when songs are added to the repo."""
     repo = SongRepository()
     model = SongTableModel(repo)
     repo.addFile(song_path)
     assert model.rowCount() == 1
-    assert model.columnCount() == len(prefs.settings.table_tags)
+    assert model.columnCount() == len(mock_settings.table_tags)
 
 
 def test_SongTableModel_headerData_no_songs() -> None:
@@ -52,7 +54,9 @@ def test_SongTableModel_headerData_no_songs() -> None:
     )
 
 
-def test_SongTableModel_headerData_songs_added(song_paths: list[PathLike[str]]) -> None:
+def test_SongTableModel_headerData_songs_added(
+    song_paths: list[PathLike[str]], mock_settings: MagicMock
+) -> None:
     """Test that headers display when songs are added."""
     repo = SongRepository()
     model = SongTableModel(repo)
@@ -68,7 +72,7 @@ def test_SongTableModel_headerData_songs_added(song_paths: list[PathLike[str]]) 
     )
     assert (
         model.headerData(0, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
-        == prefs.settings.table_tags[0].display_name
+        == mock_settings.table_tags[0].display_name
     )
     assert (
         model.headerData(0, Qt.Orientation.Horizontal, Qt.ItemDataRole.EditRole) is None
@@ -80,7 +84,7 @@ def test_SongTableModel_headerData_songs_added(song_paths: list[PathLike[str]]) 
     # Invalid section indexes should be None
     assert (
         model.headerData(
-            len(prefs.settings.table_tags),
+            len(mock_settings.table_tags),
             Qt.Orientation.Horizontal,
             Qt.ItemDataRole.DisplayRole,
         )
@@ -104,7 +108,9 @@ def test_SongTableModel_data_no_songs() -> None:
     assert model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole) is None
 
 
-def test_SongTableModel_data(song_paths: list[PathLike[str]]) -> None:
+def test_SongTableModel_data(
+    song_paths: list[PathLike[str]], mock_settings: MagicMock
+) -> None:
     """Test that data returns the correct type when songs exist.
 
     Assuming that a valid role and index is used.

--- a/tests/models/test_song_repository.py
+++ b/tests/models/test_song_repository.py
@@ -1,5 +1,7 @@
 """Tests for SongRepository."""
 
+# pyright: reportUnusedParameter = false, reportMissingSuperCall = false
+
 from os import PathLike
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -11,6 +13,20 @@ from music_modify.custom_types.song import Song
 from music_modify.models.song_repository import SongRepository
 
 
+class _MockSong(Song):
+    """Mock the Song class to not call __init__."""
+
+    def __init__(self, file: str | PathLike[str] | None = None) -> None:
+        """Deliberately _not_ calling super, so we don't need to stress about prefs."""
+        self.file = file
+
+
+@pytest.fixture
+def mock_song(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fixture for mocking the Song class."""
+    monkeypatch.setattr("music_modify.models.song_repository.Song", _MockSong)
+
+
 def test_SongRepository_getSong_invalid_index() -> None:
     """Test that None is returned when trying to get a song at an invalid index."""
     repo = SongRepository()
@@ -18,7 +34,7 @@ def test_SongRepository_getSong_invalid_index() -> None:
     assert repo[1] is None
 
 
-def test_SongRepository_getSong_valid_index() -> None:
+def test_SongRepository_getSong_valid_index(mock_song: None) -> None:
     """Test that a Song is returned when using a valid index."""
     repo = SongRepository()
     repo.addSong()
@@ -26,10 +42,10 @@ def test_SongRepository_getSong_valid_index() -> None:
     assert isinstance(repo[0], Song)
 
 
-def test_SongRepository_contains(song_path: Path) -> None:
+def test_SongRepository_contains(song_path: Path, mock_song: None) -> None:
     """Test that contains returns True if the song is present, otherwise False."""
     repo = SongRepository()
-    song1 = Song()
+    song1 = _MockSong()
     assert (song1 in repo) is False
     repo.addSong(song1)
     assert (song1 in repo) is True
@@ -38,7 +54,9 @@ def test_SongRepository_contains(song_path: Path) -> None:
     assert (song_path in repo) is True
 
 
-def test_SongRepository_addFile_single(song_path: Path, qtbot: QtBot) -> None:
+def test_SongRepository_addFile_single(
+    song_path: Path, qtbot: QtBot, mock_song: None
+) -> None:
     """Test that adding a file that doesn't exist works."""
     repo = SongRepository()
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
@@ -48,7 +66,9 @@ def test_SongRepository_addFile_single(song_path: Path, qtbot: QtBot) -> None:
     assert song.file == song_path
 
 
-def test_SongRepository_addFile_exists_rejected(song_path: Path, qtbot: QtBot) -> None:
+def test_SongRepository_addFile_exists_rejected(
+    song_path: Path, qtbot: QtBot, mock_song: None
+) -> None:
     """Tests that adding a file that exists doesn't add it again."""
     repo = SongRepository()
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
@@ -60,17 +80,17 @@ def test_SongRepository_addFile_exists_rejected(song_path: Path, qtbot: QtBot) -
     assert song.file == song_path
 
 
-def test_SongRepository_addSong_with_song(qtbot: QtBot) -> None:
+def test_SongRepository_addSong_with_song(qtbot: QtBot, mock_song: None) -> None:
     """Tests that calling addSong with a song adds it the repo."""
     repo = SongRepository()
-    song = Song()
+    song = _MockSong()
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.addSong(song)
     assert len(repo) == 1
     assert repo[0] == song
 
 
-def test_SongRepository_addSong_with_None(qtbot: QtBot) -> None:
+def test_SongRepository_addSong_with_None(qtbot: QtBot, mock_song: None) -> None:
     """Tests that calling addSong with None creates a song and adds it."""
     repo = SongRepository()
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
@@ -79,7 +99,9 @@ def test_SongRepository_addSong_with_None(qtbot: QtBot) -> None:
     assert isinstance(repo[0], Song)
 
 
-def test_SongRepository_addFiles_adds_multiple(song_paths: list[PathLike[str]]) -> None:
+def test_SongRepository_addFiles_adds_multiple(
+    song_paths: list[PathLike[str]], mock_song: None
+) -> None:
     """Test that multiple songs are added when calling addFiles."""
     repo = SongRepository()
     repo.songs_updated = MagicMock()
@@ -92,7 +114,9 @@ def test_SongRepository_addFiles_adds_multiple(song_paths: list[PathLike[str]]) 
     assert repo.songs_updated.emit.call_count == len(repo)
 
 
-def test_SongRepository_clearFiles(song_path: Path, qtbot: QtBot) -> None:
+def test_SongRepository_clearFiles(
+    song_path: Path, qtbot: QtBot, mock_song: None
+) -> None:
     """Test that clearing files makes the repo empty."""
     repo = SongRepository()
     repo.addFile(song_path)
@@ -103,7 +127,7 @@ def test_SongRepository_clearFiles(song_path: Path, qtbot: QtBot) -> None:
 
 
 def test_SongRepository_removeSongs_single(
-    song_paths: list[PathLike[str]], qtbot: QtBot
+    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
 ) -> None:
     """Test that removing a single song from the repo works."""
     repo = SongRepository()
@@ -115,7 +139,7 @@ def test_SongRepository_removeSongs_single(
 
 
 def test_SongRepository_removeSongs_multiple(
-    song_paths: list[PathLike[str]], qtbot: QtBot
+    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
 ) -> None:
     """Test that removing multiple songs from the repo works."""
     repo = SongRepository()
@@ -127,7 +151,7 @@ def test_SongRepository_removeSongs_multiple(
 
 
 def test_SongRepository_removeSongs_empty_indexes(
-    song_paths: list[PathLike[str]], qtbot: QtBot
+    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
 ) -> None:
     """Test that the repo doesn't change, and songs_updated isn't emitted."""
     repo = SongRepository()
@@ -137,7 +161,9 @@ def test_SongRepository_removeSongs_empty_indexes(
     assert len(repo) == len(song_paths)
 
 
-def test_SongRepository_refreshDisplay(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_SongRepository_refreshDisplay(
+    monkeypatch: pytest.MonkeyPatch, mock_song: None
+) -> None:
     """Test that refreshDisplay calls updateInfo for each song in songs."""
     mock_update_info = MagicMock()
     monkeypatch.setattr(Song, "updateInfo", mock_update_info)
@@ -148,7 +174,9 @@ def test_SongRepository_refreshDisplay(monkeypatch: pytest.MonkeyPatch) -> None:
     for _ in range(num_songs):
         repo.addSong()
 
+    # Reset to not worry about the init calls
+    mock_update_info.reset_mock()
+
     repo.refreshDisplay()
 
-    # Needs to be twice, because updateInfo is called in init as well
-    assert mock_update_info.call_count == 2 * num_songs
+    assert mock_update_info.call_count == num_songs

--- a/tests/prefs/test_prefs.py
+++ b/tests/prefs/test_prefs.py
@@ -1,5 +1,14 @@
 """Tests for Settings."""
 
+# pyright: reportPrivateUsage = false, reportUnusedParameter = false
+
+import logging
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import QApplication
+import pytest
+
 from music_modify.custom_types import SongTag, TagInfo
 from music_modify.prefs.prefs import Settings
 
@@ -66,7 +75,7 @@ def test_Settings_resetSplit(temp_settings: Settings) -> None:
     assert temp_settings.split_values_display == Settings.default_split_values_display
 
 
-def test_resetTags(temp_settings: Settings) -> None:
+def test_Settings_resetTags(temp_settings: Settings) -> None:
     """Test that resetting tags changes back to the original default ones."""
     _set_tag_values(temp_settings)
     temp_settings.resetTags()
@@ -83,3 +92,94 @@ def test_resetTags(temp_settings: Settings) -> None:
         for tag in Settings.default_tags
         if tag.show_in_table
     ]
+
+
+def test_Settings_configureForApplication_already_configured_warns(
+    temp_settings: Settings,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that configureForApplication warns if already configured.
+
+    The internal QSettings object should not change.
+    `_initializeDefaults` should not be called.
+    """
+    mock_initializeDefaults = MagicMock()
+    monkeypatch.setattr(temp_settings, "_initializeDefaults", mock_initializeDefaults)
+
+    original_settings_obj = temp_settings._settings
+    expected_warning = "QSettings already configured. Skipping re-configuration."
+
+    with caplog.at_level(logging.WARNING):
+        temp_settings.configureForApplication()
+
+    assert expected_warning in caplog.text
+    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].message == expected_warning
+
+    mock_initializeDefaults.assert_not_called()
+
+    assert original_settings_obj is temp_settings._settings
+
+
+def test_Settings_configureForApplication_no_QApplication_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that configureForApplication errors if QApplication instance is None."""
+    unset_settings = Settings(new_settings=None)
+
+    mock_initializeDefaults = MagicMock()
+    monkeypatch.setattr(unset_settings, "_initializeDefaults", mock_initializeDefaults)
+
+    monkeypatch.setattr(QApplication, "instance", MagicMock(return_value=None))
+
+    expected_error = "Called configure when there was not a QApplication instance."
+
+    with caplog.at_level(logging.ERROR):
+        unset_settings.configureForApplication()
+
+    assert expected_error in caplog.text
+    assert caplog.records[0].levelname == "ERROR"
+    assert caplog.records[0].message == expected_error
+
+    mock_initializeDefaults.assert_not_called()
+    assert unset_settings._settings is None
+
+
+def test_Settings_configureForApplication_initializes_QSettings_and_defaults(
+    qapp: QApplication,
+    app_info: tuple[str, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that configureForApplication inits QSettings; calls _initializeDefaults."""
+    app_org_name, app_app_name, _ = app_info
+
+    unset_settings = Settings(new_settings=None)
+
+    mock_qsettings_instance = MagicMock(spec=QSettings)
+    mock_qsettings_constructor = MagicMock(return_value=mock_qsettings_instance)
+    monkeypatch.setattr(
+        "music_modify.prefs.prefs.QSettings", mock_qsettings_constructor
+    )
+
+    mock_initializeDefaults = MagicMock()
+    monkeypatch.setattr(unset_settings, "_initializeDefaults", mock_initializeDefaults)
+
+    unset_settings.configureForApplication()
+
+    mock_qsettings_constructor.assert_called_once_with(app_org_name, app_app_name)
+    assert unset_settings._settings is mock_qsettings_instance
+    mock_initializeDefaults.assert_called_once()
+
+
+def test_Settings_getQSettings_uninitialized_raises_RuntimeError() -> None:
+    """Test that _getQSettings raises RuntimeError if not configured."""
+    unset_settings = Settings(new_settings=None)
+    expected_exception_message = (
+        "Settings have not been configured for the application."
+    )
+    with pytest.raises(RuntimeError, match=expected_exception_message) as exc_info:
+        unset_settings._getQSettings()
+
+    assert expected_exception_message in str(exc_info.value)


### PR DESCRIPTION
Instead of hard-coding the app info in two places, it should use the info that is set in QApplication. This requires that the QSettings variable is set _after_ the QApplication is initialized, so it introduces a method `configureForApplication` that creates the QSettings instance variable at the right time.