### PR TITLE
refactor(settings)!: Make Settings a QObject and not global

### DIFF
--- a/src/music_modify/custom_types/song.py
+++ b/src/music_modify/custom_types/song.py
@@ -8,8 +8,6 @@ import os
 
 from mutagen.id3 import ID3
 
-from music_modify.prefs import prefs
-
 from .aliases import SongEditData, SongGroupData
 from .songtag import SongTag
 from .utils import toTag, valueToString
@@ -20,15 +18,28 @@ logger = logging.getLogger(__name__)
 class Song:
     """Object representing data about an mp3 file."""
 
-    def __init__(self, file: str | os.PathLike[str] | None = None) -> None:
+    def __init__(
+        self,
+        all_tags: list[SongTag],
+        table_tags: list[SongTag],
+        display_split: str,
+        file: str | os.PathLike[str] | None = None,
+    ) -> None:
         """Creates a Song object from a provided file.
 
         If `file` is `None`, it creates an empty ID3 that is not related
         to any specific file.
 
         Args:
+            all_tags: The tags that should be accessible and updateable.
+            table_tags: The tags that should be used for generating columns.
+            display_split: The character used for splitting values when they
+                store multiple items.
             file: The file that the metadata should be loaded from.
         """
+        self._all_tags: list[SongTag] = all_tags
+        self._table_tags: list[SongTag] = table_tags
+        self._display_split: str = display_split
         self.file: str | os.PathLike[str] | None = file
         "The file on disk that this `Song` object represents."
         self.id3: ID3 = ID3()
@@ -42,10 +53,9 @@ class Song:
     def _generateColumns(self) -> list[str]:
         """Generate display values for the columns that should be shown in the table."""
         info: list[str] = []
-        for column in prefs.settings.table_tags:
+        for column in self._table_tags:
             data_string = valueToString(
-                value=self.getValue(column),
-                display_split=prefs.settings.split_values_display,
+                value=self.getValue(column), display_split=self._display_split
             )
             info.append(data_string)
         return info
@@ -71,9 +81,7 @@ class Song:
 
     def setTag(self, tag: str | SongTag, value: SongGroupData) -> None:
         """Set the tag within the file to have the value specified."""
-        found_tag = (
-            toTag(tag, prefs.settings.all_tags) if not isinstance(tag, SongTag) else tag
-        )
+        found_tag = toTag(tag, self._all_tags) if not isinstance(tag, SongTag) else tag
         if found_tag is not None:
             found_tag.setTag(self.id3, value)
 
@@ -82,27 +90,21 @@ class Song:
 
         Returns `None`, if the tag is not present.
         """
-        found_tag = (
-            toTag(tag, prefs.settings.all_tags) if not isinstance(tag, SongTag) else tag
-        )
+        found_tag = toTag(tag, self._all_tags) if not isinstance(tag, SongTag) else tag
         if found_tag is None:
             return None
         return found_tag.getValue(self.id3)
 
     def removeTag(self, tag: str | SongTag) -> None:
         """Remove the tag from the stored metadata for a song, if it exists."""
-        found_tag = (
-            toTag(tag, prefs.settings.all_tags) if not isinstance(tag, SongTag) else tag
-        )
+        found_tag = toTag(tag, self._all_tags) if not isinstance(tag, SongTag) else tag
         if found_tag is None:
             return
         found_tag.removeTag(self.id3)
 
     def hasTag(self, tag: str | SongTag) -> bool:
         """Returns `True` if the tag is defined in the metadata for the song."""
-        found_tag = (
-            toTag(tag, prefs.settings.all_tags) if not isinstance(tag, SongTag) else tag
-        )
+        found_tag = toTag(tag, self._all_tags) if not isinstance(tag, SongTag) else tag
         if found_tag is None:
             return False
         return found_tag.hasTag(self.id3)

--- a/src/music_modify/gui/completion/_complete_line_edit.py
+++ b/src/music_modify/gui/completion/_complete_line_edit.py
@@ -10,8 +10,6 @@ from PySide6.QtCore import QEvent, QModelIndex, Qt, Signal, Slot
 from PySide6.QtGui import QKeyEvent
 from PySide6.QtWidgets import QLineEdit, QWidget
 
-from music_modify.prefs import prefs
-
 from ._completer import Completer
 
 
@@ -26,6 +24,7 @@ class EnLineEdit(QLineEdit):
 
     def __init__(
         self,
+        split_text_entered: str = ", ",
         parent: QWidget | None = None,
         completer_widget: QWidget | None = None,
         *,
@@ -35,6 +34,7 @@ class EnLineEdit(QLineEdit):
         """Create a line edit that has a popup for completion suggestions.
 
         Args:
+            split_text_entered: Character used to split values when there are multiple.
             parent: The widget that this widget should be displayed on.
             completer_widget: The widget that completion items should be displayed on.
                 If not set, defaults to this widget itself.
@@ -42,6 +42,7 @@ class EnLineEdit(QLineEdit):
             multiple: Whether multiple items can be displayed and selected,
                 or only single items.
         """
+        self._split_text_entered = split_text_entered
         super().__init__(parent)
         self.setClearButtonEnabled(True)
 
@@ -138,7 +139,7 @@ class EnLineEdit(QLineEdit):
         prefix = text[:cpos]
         complete_prefix = prefix.lstrip()
         if self.multiple:
-            sep = prefs.settings.split_text_entered
+            sep = self._split_text_entered
             complete_prefix = prefix.split(sep)[-1].lstrip()
         self.mcompleter.setCompletionPrefix(complete_prefix)
 
@@ -146,7 +147,7 @@ class EnLineEdit(QLineEdit):
         """Get the list of completed items in before and after parts."""
         if not self.multiple:
             return text, ""
-        sep = prefs.settings.split_text_entered
+        sep = self._split_text_entered
         cursor_pos = self.original_cursor_pos
         if cursor_pos is None:
             cursor_pos = self.cursorPosition()
@@ -179,7 +180,7 @@ class EnLineEdit(QLineEdit):
     def applyCurrentText(self) -> None:
         """Use the current text as a selection."""
         if self.multiple:
-            sep = prefs.settings.split_text_entered
+            sep = self._split_text_entered
             text = str(self.text())
             sep_pos = text.rfind(sep)
             if sep_pos:

--- a/src/music_modify/gui/completion/edit_with_complete.py
+++ b/src/music_modify/gui/completion/edit_with_complete.py
@@ -8,7 +8,6 @@ from PySide6.QtCore import QEvent, QObject, Qt, Signal, SignalInstance
 from PySide6.QtGui import QKeyEvent
 from PySide6.QtWidgets import QComboBox, QSizePolicy, QWidget
 
-from music_modify.prefs import prefs
 from music_modify.utils import getUnique
 
 from ._complete_line_edit import EnLineEdit
@@ -25,6 +24,7 @@ class EditWithComplete(QComboBox):
     def __init__(
         self,
         parent: QWidget,
+        split_text_entered: str = ", ",
         items: tuple[str, ...] | None = None,
         *,
         multiple: bool = True,
@@ -34,15 +34,20 @@ class EditWithComplete(QComboBox):
 
         Args:
             parent: The widget that this widget should be displayed on.
+            split_text_entered: Character used to split values when there are multiple
             items: The completion suggestions for the widget on initialization.
             multiple: Whether multiple values should be allowed as output.
             initial: The initial value to display in the widget.
         """
         super().__init__(parent)
         self.setMinimumContentsLength(20)
+        self.split_text_entered = split_text_entered
 
         self.line_edit: EnLineEdit = EnLineEdit(
-            self, completer_widget=self, multiple=multiple
+            parent=self,
+            completer_widget=self,
+            multiple=multiple,
+            split_text_entered=split_text_entered,
         )
         self.setLineEdit(self.line_edit)
         self.line_edit.item_selected.connect(self.item_selected)
@@ -175,4 +180,4 @@ class EditWithComplete(QComboBox):
         The text is split by the setting value for `split_text_entered`.
         """
         text = self.text()
-        return getUnique(text, prefs.settings.split_text_entered)
+        return getUnique(text, self.split_text_entered)

--- a/src/music_modify/gui/edit/bulk/dialog_edit_bulk.py
+++ b/src/music_modify/gui/edit/bulk/dialog_edit_bulk.py
@@ -16,10 +16,10 @@ from PySide6.QtWidgets import (
 )
 
 from music_modify.custom_types.enums import EditorType
+from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.dialog_edit_abstract import EditAbstractDialog
 from music_modify.gui.utils import createTab
 from music_modify.models.song_repository import SongRepository
-from music_modify.prefs import prefs
 from music_modify.utils.list_utils import addValues
 
 from .widget_edit_bulk_abstract import EditBulkAbstractWidget
@@ -29,7 +29,6 @@ from .widget_edit_bulk_people import EditBulkPeopleWidget
 
 if TYPE_CHECKING:
     from music_modify.custom_types.song import Song
-    from music_modify.custom_types.songtag import SongTag
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +76,8 @@ class EditBulkDialog(EditAbstractDialog):
         parent: QWidget,
         repository: SongRepository,
         rows: list[int],
+        split_text_entered: str,
+        all_tags: list[SongTag],
     ) -> None:
         """Create a dialog for bulk editing songs.
 
@@ -84,8 +85,13 @@ class EditBulkDialog(EditAbstractDialog):
             parent: The widget that the dialog should be displayed on
             repository: The list of songs being managed
             rows: The indexes of the songs to edit, in the `repository`
+            split_text_entered: Character used to split values when multiple are entered
+            all_tags: Tags that are available for reading and editing
         """
         super().__init__(parent, repository, rows)
+
+        self._split_text_entered: str = split_text_entered
+        self._all_tags: list[SongTag] = all_tags
 
         if len(rows) == 0:
             self.reject()
@@ -131,7 +137,7 @@ class EditBulkDialog(EditAbstractDialog):
         people_values: dict[SongTag, list[list[str]]] = {}
         normal_values: dict[SongTag, set[str]] = {}
 
-        for tag in prefs.settings.all_tags:
+        for tag in self._all_tags:
             # Get values from all songs, and store in dicts
             in_all: bool = True
             for song in self.songs:
@@ -171,7 +177,10 @@ class EditBulkDialog(EditAbstractDialog):
                 case EditorType.MultipleText:
                     multi_widget_layout.addWidget(
                         EditBulkMultipleWidget(
-                            self, normal_values.get(tag, set()), tag
+                            self,
+                            normal_values.get(tag, set()),
+                            tag,
+                            self._split_text_entered,
                         ),
                     )
                 case EditorType.SingleText:
@@ -182,6 +191,7 @@ class EditBulkDialog(EditAbstractDialog):
                             normal_values.get(tag, set()),
                             tag,
                             in_all=in_all,
+                            split_text_entered=self._split_text_entered,
                         ),
                     )
                 case _:

--- a/src/music_modify/gui/edit/bulk/widget_edit_bulk_line.py
+++ b/src/music_modify/gui/edit/bulk/widget_edit_bulk_line.py
@@ -29,6 +29,7 @@ class EditBulkLineWidget(EditBulkAbstractWidget):
         parent: QWidget,
         data: set[str],
         tag: SongTag,
+        split_text_entered: str,
         *,
         in_all: bool = False,
     ) -> None:
@@ -39,6 +40,7 @@ class EditBulkLineWidget(EditBulkAbstractWidget):
             data: The data to be displayed.
             tag: The field in the song that should be updated.
             in_all: Whether the data appears in all songs being edited or not.
+            split_text_entered: Character used to split values when multiple entered
         """
         super().__init__(parent, tag)
 
@@ -53,6 +55,7 @@ class EditBulkLineWidget(EditBulkAbstractWidget):
             items=self.items,
             multiple=False,
             initial=initial,
+            split_text_entered=split_text_entered,
         )
 
         self.setupUi()

--- a/src/music_modify/gui/edit/bulk/widget_edit_bulk_multiple.py
+++ b/src/music_modify/gui/edit/bulk/widget_edit_bulk_multiple.py
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import (
 from music_modify.custom_types import Song, SongTag
 from music_modify.custom_types.qt_types import QLineEditArgs
 from music_modify.gui.completion import EditWithComplete
-from music_modify.prefs import prefs
 from music_modify.utils import getUnique
 
 from .widget_edit_bulk_abstract_group import EditBulkAbstractGroupWidget
@@ -31,32 +30,39 @@ class _MultipleLineEdit(QLineEdit):
     def __init__(
         self,
         value: str,
+        split_text_entered: str,
         parent: QWidget | None = None,
         **kwargs: Unpack[QLineEditArgs],
     ) -> None:
         super().__init__(value, parent, **kwargs)
+        self._split_text_entered = split_text_entered
 
     @property
     def items(self) -> list[str]:
         """The list of strings that is displayed."""
         text = self.text()
-        return getUnique(text, prefs.settings.split_text_entered)
+        return getUnique(text, self._split_text_entered)
 
 
 class EditBulkMultipleWidget(EditBulkAbstractGroupWidget):
     """Widget used for bulk editing data when the tag contains multiple values."""
 
-    def __init__(self, parent: QWidget, data: set[str], tag: SongTag) -> None:
+    def __init__(
+        self, parent: QWidget, data: set[str], tag: SongTag, split_text_entered: str
+    ) -> None:
         """Create a widget for bulk editing multiple value keys.
 
         Args:
-            parent: The widget that this widget shouldbe displayed on.
+            parent: The widget that this widget should be displayed on.
             data: The data to be displayed.
             tag: The field in the song that should be updated.
+            split_text_entered: The string that is used to split values
+                when multiple are entered.
         """
         super().__init__(parent, tag)
 
         self.items: tuple[str, ...] = tuple(data)
+        self._split_text_entered = split_text_entered
         self.setupUi()
 
         self.add_line: _MultipleLineEdit
@@ -71,7 +77,7 @@ class EditBulkMultipleWidget(EditBulkAbstractGroupWidget):
         form_layout.setContentsMargins(0, 0, 0, 0)
 
         add_layout = QHBoxLayout()
-        self.add_line = _MultipleLineEdit("")
+        self.add_line = _MultipleLineEdit("", self._split_text_entered)
         add_layout.addWidget(self.add_line)
         form_layout.addRow("Add", add_layout)
 

--- a/src/music_modify/gui/edit/bulk/widget_edit_bulk_people.py
+++ b/src/music_modify/gui/edit/bulk/widget_edit_bulk_people.py
@@ -169,15 +169,24 @@ AllowedActionMapping = (
 class EditBulkPeopleWidget(EditBulkAbstractGroupWidget):
     """Widget used for bulk editing values that are [role, person] pairs."""
 
-    def __init__(self, parent: QWidget, data: list[list[str]], tag: SongTag) -> None:
+    def __init__(
+        self,
+        parent: QWidget,
+        data: list[list[str]],
+        tag: SongTag,
+        split_text_entered: str = ", ",
+    ) -> None:
         """Create an EditBulkPeopleWidget.
 
         Args:
             parent: The widget that this widget should be displayed on.
             data: The data to be displayed.
             tag: The field in the song that should be updated.
+            split_text_entered: Character used to separate values when multiple
         """
         super().__init__(parent, tag)
+
+        self._split_text_entered = split_text_entered
 
         self.items: list[tuple[str, str]] = [(role, person) for role, person in data]
         self.setupUi()
@@ -203,15 +212,13 @@ class EditBulkPeopleWidget(EditBulkAbstractGroupWidget):
             {f"{role}{PAIR_SEPARATOR}{person}" for (role, person) in self.items},
         )
         self.remove_pair_widget = EditWithComplete(
-            parent=self,
-            items=tuple(pairs),
+            parent=self, items=tuple(pairs), split_text_entered=self._split_text_entered
         )
         form_layout.addRow("Remove Pair", self.remove_pair_widget)
 
         roles = list({role for (role, _) in self.items})
         self.remove_role_widget = EditWithComplete(
-            parent=self,
-            items=tuple(roles),
+            parent=self, items=tuple(roles), split_text_entered=self._split_text_entered
         )
         form_layout.addRow("Remove Role", self.remove_role_widget)
 
@@ -219,6 +226,7 @@ class EditBulkPeopleWidget(EditBulkAbstractGroupWidget):
         self.remove_person_widget = EditWithComplete(
             parent=self,
             items=tuple(people),
+            split_text_entered=self._split_text_entered,
         )
         form_layout.addRow("Remove Person", self.remove_person_widget)
 

--- a/src/music_modify/gui/edit/dialog_edit.py
+++ b/src/music_modify/gui/edit/dialog_edit.py
@@ -20,7 +20,6 @@ from music_modify.custom_types.enums import NavDirection
 from music_modify.custom_types.utils import mapKey
 from music_modify.gui.utils import clearLayout
 from music_modify.models.song_repository import SongRepository
-from music_modify.prefs import prefs
 
 from .dialog_edit_abstract import EditAbstractDialog
 from .widget_edit_abstract import EditAbstractWidget
@@ -37,6 +36,7 @@ class EditDialog(EditAbstractDialog):
         parent: QWidget,
         repository: SongRepository,
         rows: list[int],
+        all_tags: list[SongTag],
     ) -> None:
         """Creates a dialog for editing songs individually.
 
@@ -44,8 +44,11 @@ class EditDialog(EditAbstractDialog):
             parent: The widget that the dialog should be displayed on.
             repository: The list of songs being managed by the app.
             rows: The indexes of the songs to be edited in the `repository`.
+            all_tags: Tags that are available for reading and editing
         """
         super().__init__(parent, repository, rows)
+
+        self._all_tags: list[SongTag] = all_tags
 
         if len(rows) == 0:
             self.reject()
@@ -109,7 +112,7 @@ class EditDialog(EditAbstractDialog):
         else:
             self.song_layout = QFormLayout(scroll_widget)
 
-        for tag in prefs.settings.all_tags:
+        for tag in self._all_tags:
             # Needs to be a copy to avoid editing the tag prematurely.
             current_data = copy.deepcopy(tag.getValue(self.song_info.id3))
             widget = self._createWidgetType(tag, current_data)
@@ -219,7 +222,7 @@ class EditDialog(EditAbstractDialog):
         logger.debug("Called updateSong")
         any_updated = False
         for id3_key, value in self.changed_values.items():
-            tag: SongTag | None = mapKey(id3_key, prefs.settings.all_tags)
+            tag: SongTag | None = mapKey(id3_key, self._all_tags)
             if tag is None:
                 logger.debug(f"Unknown id3 key: {id3_key}")
                 continue

--- a/src/music_modify/gui/edit/dialog_edit_factory.py
+++ b/src/music_modify/gui/edit/dialog_edit_factory.py
@@ -5,6 +5,7 @@ This is the factory class for creating different types of Edit dialogs.
 
 from PySide6.QtWidgets import QWidget
 
+from music_modify.custom_types.songtag import SongTag
 from music_modify.models.song_repository import SongRepository
 
 from .bulk.dialog_edit_bulk import EditBulkDialog
@@ -24,12 +25,20 @@ class EditDialogFactory:
         Args:
             parent: The widget the new widget should be created on.
             repository: The list of songs the app is managing.
+            all_tags:
         """
         self.parent: QWidget = parent
         self.repository: SongRepository = repository
         "The list of songs that the app is managing"
 
-    def get(self, rows: list[int], *, bulk: bool = False) -> EditAbstractDialog:
+    def get(
+        self,
+        rows: list[int],
+        all_tags: list[SongTag],
+        split_text_entered: str,
+        *,
+        bulk: bool = False,
+    ) -> EditAbstractDialog:
         """Generates an EditAbstractDialog.
 
         The dialog generated is based on whether multiple files should be edited.
@@ -38,6 +47,8 @@ class EditDialogFactory:
 
         Args:
             rows: List of indexes in the repository for the songs to edit
+            all_tags: Tags that can be viewed and edited.
+            split_text_entered: Character used to split multiple values.
             bulk (optional): Whether the songs should be edited in bulk or individually.
                 Default False.
 
@@ -45,5 +56,7 @@ class EditDialogFactory:
             A dialog for editing the metadata, of the correct form.
         """
         if bulk:
-            return EditBulkDialog(self.parent, self.repository, rows)
-        return EditDialog(self.parent, self.repository, rows)
+            return EditBulkDialog(
+                self.parent, self.repository, rows, split_text_entered, all_tags
+            )
+        return EditDialog(self.parent, self.repository, rows, all_tags)

--- a/src/music_modify/gui/main/window_main.py
+++ b/src/music_modify/gui/main/window_main.py
@@ -34,6 +34,7 @@ from music_modify.gui.edit import EditDialogFactory
 from music_modify.gui.prefs import PrefsDialog
 from music_modify.gui.utils import getSelectedRows, updateTableView
 from music_modify.models import SongRepository, SongTableModel
+from music_modify.prefs import Settings
 from music_modify.utils import formatTime
 
 logger = logging.getLogger(__name__)
@@ -42,10 +43,12 @@ logger = logging.getLogger(__name__)
 class MainWindow(QMainWindow):
     """Main interface window for managing song metadata."""
 
-    def __init__(self) -> None:
+    def __init__(self, settings: Settings) -> None:
         """Creates the main user interface."""
         super().__init__()
         self._setupUi()
+
+        self._settings = settings
 
         # Create separate QLabel widgets instead of using the statbusbar default ones,
         # so that they're not overridden when a QStatusTipEvent happens.
@@ -56,10 +59,18 @@ class MainWindow(QMainWindow):
         "Label that contains information about how many songs are present and selected"
         self.statusbar.addWidget(self.statusLabel)
 
-        self.songs_repository: Final[SongRepository] = SongRepository()
+        self.songs_repository: Final[SongRepository] = SongRepository(
+            self._settings.all_tags,
+            self._settings.table_tags,
+            self._settings.split_values_display,
+        )
         "Repository that stores the songs being managed"
-        self.songs_model: Final[SongTableModel] = SongTableModel(self.songs_repository)
+        self.songs_model: Final[SongTableModel] = SongTableModel(
+            self.songs_repository, self._settings.table_tags
+        )
         "Model that links between the song repository and the display of the metadata"
+
+        self._settings.tags_updated.connect(self.refreshTable)
 
         self.dialog_factory: EditDialogFactory = EditDialogFactory(
             self,
@@ -77,7 +88,9 @@ class MainWindow(QMainWindow):
             self.setSelectionActionState,
         )
         self.songs_repository.songs_updated.connect(
-            lambda: updateTableView(self.files_table_view, self.songs_repository),
+            lambda: updateTableView(
+                self.files_table_view, self.songs_repository, self._settings.table_tags
+            ),
         )
         self.files_table_view.customContextMenuRequested.connect(
             self.showCustomContextMenu,
@@ -286,16 +299,18 @@ class MainWindow(QMainWindow):
 
     def showPrefsDialog(self) -> None:
         """Show a PreferencesDialog."""
-        prefs_dialog = PrefsDialog(parent=self)
+        prefs_dialog = PrefsDialog(parent=self, settings=self._settings)
         prefs_dialog.show()
-        prefs_dialog.settings_updated.connect(self.refreshTable)
 
     def refreshTable(self) -> None:
         """Update the display of the table."""
         self.songs_model.layoutAboutToBeChanged.emit()
+        self.songs_model.updateTableTags(self._settings.table_tags)
         self.songs_repository.refreshDisplay()
         self.songs_model.layoutChanged.emit()
-        updateTableView(self.files_table_view, self.songs_repository)
+        updateTableView(
+            self.files_table_view, self.songs_repository, self._settings.table_tags
+        )
 
     def showEditDialog(self, *, bulk: bool = False) -> None:
         """Create a dialog for editing the metadata in the selected songs.
@@ -313,7 +328,9 @@ class MainWindow(QMainWindow):
         if len(rows) == 0:
             return
 
-        dialog = self.dialog_factory.get(rows, bulk=bulk)
+        dialog = self.dialog_factory.get(
+            rows, self._settings.all_tags, self._settings.split_text_entered, bulk=bulk
+        )
 
         def processDialogResult(result: QDialog.DialogCode) -> None:
             logger.debug("Called process dialog result for edit dialog")

--- a/src/music_modify/gui/prefs/dialog_prefs.py
+++ b/src/music_modify/gui/prefs/dialog_prefs.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -11,6 +11,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from music_modify.prefs import Settings
 
 from .dialog_prefs_abstract import PrefsAbstractDialog
 from .dialog_prefs_split import PrefsSplitDialog
@@ -23,17 +25,17 @@ logger.setLevel(logging.INFO)
 class PrefsDialog(QDialog):
     """A dialog that allows the user to change the settings the program uses."""
 
-    settings_updated: Signal = Signal()
-    "Signal that is emitted whenever any setting is changed."
-
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, settings: Settings, parent: QWidget | None = None) -> None:
         """Create a PrefsDialog.
 
         Args:
+            settings: Settings object to read from and update.
             parent: The widget that the dialog should be displayed on.
         """
         super().__init__(parent)
         self.setupUi()
+
+        self._settings: Settings = settings
 
         self.button_edit_tags.clicked.connect(
             lambda: self.openChildDialog(PrefsTagDialog),
@@ -48,10 +50,8 @@ class PrefsDialog(QDialog):
         Args:
             dialog_type: The specific type of child dialog that should be opened.
         """
-        dialog = dialog_type(self)
+        dialog = dialog_type(self._settings, self)
         dialog.setModal(True)
-
-        dialog.settings_updated.connect(lambda: self.settings_updated.emit())
 
         dialog.show()
 

--- a/src/music_modify/gui/prefs/dialog_prefs_abstract.py
+++ b/src/music_modify/gui/prefs/dialog_prefs_abstract.py
@@ -8,10 +8,11 @@ from abc import ABC, abstractmethod
 import logging
 from typing import final
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QWidget
 
 from music_modify.gui.meta import ABCQMeta
+from music_modify.prefs import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,19 +20,18 @@ logger = logging.getLogger(__name__)
 class PrefsAbstractDialog(QDialog, ABC, metaclass=ABCQMeta):
     """Defines the required functionality for all child preference dialogs."""
 
-    settings_updated: Signal = Signal()
-    "Signal that is emitted whenever any setting is changed."
-
     @abstractmethod
     def setupUi(self) -> None:
         """Set up the display of the dialog."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, settings: Settings, parent: QWidget | None = None) -> None:
         """Creates a dialog for managing preferences.
 
         Args:
+            settings: Settings object to read from and update.
             parent: The widget that the dialog should be displayed on.
         """
+        self._settings = settings
         QDialog.__init__(self, parent)
         self.setupUi()
         self.button_box: QDialogButtonBox = self._createButtonBox()

--- a/src/music_modify/gui/prefs/dialog_prefs_split.py
+++ b/src/music_modify/gui/prefs/dialog_prefs_split.py
@@ -5,7 +5,7 @@ how multiple values should be entered, and displayed.
 """
 
 import logging
-from typing import override
+from typing import Literal, override
 
 from PySide6.QtWidgets import (
     QFormLayout,
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from music_modify.prefs import prefs
+from music_modify.prefs import Settings
 
 from .dialog_prefs_abstract import PrefsAbstractDialog
 
@@ -29,13 +29,14 @@ class PrefsSplitDialog(PrefsAbstractDialog):
     when there are multiple values.
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, settings: Settings, parent: QWidget | None = None) -> None:
         """Create a PrefsSplitDialog.
 
         Args:
+            settings: Settings object to read from and update.
             parent: The widget that this dialog should be displayed on.
         """
-        super().__init__(parent)
+        super().__init__(settings, parent)
 
         self.changed_settings: dict[str, str] = {}
         """Stores the name of the setting that has been changed,
@@ -63,11 +64,17 @@ class PrefsSplitDialog(PrefsAbstractDialog):
 
     def _initializeDisplay(self) -> None:
         """Displays current values for split settings before the user changes them."""
-        self.line_edit_split_text_entered.setText(prefs.settings.split_text_entered)
-        self.line_edit_split_values_display.setText(prefs.settings.split_values_display)
-        self.line_edit_split_values_at.setText(prefs.settings.split_values_at)
+        self.line_edit_split_text_entered.setText(self._settings.split_text_entered)
+        self.line_edit_split_values_display.setText(self._settings.split_values_display)
+        self.line_edit_split_values_at.setText(self._settings.split_values_at)
 
-    def _getSettingChange(self, setting_name: str, setting_value: str) -> None:
+    def _getSettingChange(
+        self,
+        setting_name: Literal[
+            "split_text_entered", "split_values_display", "split_values_at"
+        ],
+        setting_value: str,
+    ) -> None:
         """Gets the value a specific setting has been changed to.
 
         Stores this in the list of settings to change, which will be reflected
@@ -88,7 +95,7 @@ class PrefsSplitDialog(PrefsAbstractDialog):
             _ = self.changed_settings.pop(setting_name, None)
             return
 
-        if getattr(prefs.settings, setting_name) != setting_value:
+        if getattr(self._settings, setting_name) != setting_value:
             # Set the value in changed_settings if it's different
             _ = self.changed_settings[setting_name] = setting_value
         else:
@@ -101,17 +108,16 @@ class PrefsSplitDialog(PrefsAbstractDialog):
         logger.debug("Called update settings inside split dialog")
         if len(self.changed_settings) > 0:
             for setting_name, setting_value in self.changed_settings.items():
-                setattr(prefs.settings, setting_name, setting_value)
-            self.settings_updated.emit()
+                setattr(self._settings, setting_name, setting_value)
 
     @override
     def restoreDefaults(self) -> None:
         logger.debug("Restore defaults called for split")
 
         split_defaults: dict[QLineEdit, str] = {
-            self.line_edit_split_text_entered: prefs.settings.default_split_text_entered,
-            self.line_edit_split_values_at: prefs.settings.default_split_values_at,
-            self.line_edit_split_values_display: prefs.settings.default_split_values_display,
+            self.line_edit_split_text_entered: self._settings.default_split_text_entered,
+            self.line_edit_split_values_at: self._settings.default_split_values_at,
+            self.line_edit_split_values_display: self._settings.default_split_values_display,
         }
 
         for line_edit, text in split_defaults.items():

--- a/src/music_modify/gui/prefs/dialog_prefs_tag.py
+++ b/src/music_modify/gui/prefs/dialog_prefs_tag.py
@@ -23,7 +23,7 @@ from music_modify.gui.prefs.delegate_editor_type import EditorTypeDelegate
 from music_modify.gui.utils import getSelectedRows
 from music_modify.models import TagModel
 from music_modify.models.tag_model import TAG_MODEL_COLUMNS
-from music_modify.prefs import prefs
+from music_modify.prefs import Settings
 
 from .dialog_prefs_abstract import PrefsAbstractDialog
 from .dialog_prefs_tag_add import PrefsTagAddDialog
@@ -41,17 +41,18 @@ class PrefsTagDialog(PrefsAbstractDialog, RowOperationMixin):
     and displayed for songs.
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, settings: Settings, parent: QWidget | None = None) -> None:
         """Create a PrefsTagDialog.
 
         Args:
+            settings: Settings object to read from and update.
             parent: The widget that this dialog should be displayed on.
         """
-        super().__init__(parent)
+        super().__init__(settings, parent)
         self.setWindowTitle("Edit Tags")
 
-        tags: list[TagInfo] = copy.deepcopy(prefs.settings.info_tags)
-        self.original_tags: list[TagInfo] = copy.deepcopy(prefs.settings.info_tags)
+        tags: list[TagInfo] = copy.deepcopy(self._settings.info_tags)
+        self.original_tags: list[TagInfo] = copy.deepcopy(self._settings.info_tags)
 
         self.model: TagModel = TagModel(tags)
         self.tag_table.setModel(self.model)
@@ -133,13 +134,12 @@ class PrefsTagDialog(PrefsAbstractDialog, RowOperationMixin):
     @override
     def updateSettings(self) -> None:
         logger.info("Called update settings inside tag dialog")
-        prefs.settings.info_tags = self.model.tags
-        self.settings_updated.emit()
+        self._settings.info_tags = self.model.tags
 
     @override
     def restoreDefaults(self) -> None:
         logger.debug("Restore defaults called for tag")
-        self.model.tags = prefs.settings.default_tags
+        self.model.tags = self._settings.default_tags
 
     @override
     def resetSettings(self) -> None:

--- a/src/music_modify/gui/utils.py
+++ b/src/music_modify/gui/utils.py
@@ -13,11 +13,13 @@ from PySide6.QtWidgets import (
 )
 
 from music_modify.custom_types.constants import PEOPLE_TAG_WIDTH
+from music_modify.custom_types.songtag import SongTag
 from music_modify.models import SongRepository
-from music_modify.prefs import prefs
 
 
-def updateTableView(table_view: QTableView, repository: SongRepository) -> None:
+def updateTableView(
+    table_view: QTableView, repository: SongRepository, table_tags: list[SongTag]
+) -> None:
     """Updates the appearance of the table view.
 
     Sets the column widths to the max for tags with one field,
@@ -26,7 +28,7 @@ def updateTableView(table_view: QTableView, repository: SongRepository) -> None:
     if len(repository) == 0:
         return
 
-    for index, tag in enumerate(prefs.settings.table_tags):
+    for index, tag in enumerate(table_tags):
         if len(tag) == 1:
             table_view.resizeColumnToContents(index)
         else:

--- a/src/music_modify/models/song_models.py
+++ b/src/music_modify/models/song_models.py
@@ -10,11 +10,12 @@ from PySide6.QtCore import (
     QModelIndex,
     QPersistentModelIndex,
     Qt,
+    Slot,
 )
 
 from music_modify.custom_types import constants
 from music_modify.custom_types.song import Song
-from music_modify.prefs import prefs
+from music_modify.custom_types.songtag import SongTag
 
 from .song_repository import SongRepository
 
@@ -29,15 +30,22 @@ class SongTableModel(QAbstractTableModel):
 
     empty_message: Final[str] = "Files will show here when added. Drag files here."
 
-    def __init__(self, repository: SongRepository) -> None:
+    def __init__(self, repository: SongRepository, table_tags: list[SongTag]) -> None:
         """Create a new model for the songs that should be managed.
 
         Args:
             repository: The list of songs that can be edited.
+            table_tags: The tags that should be used to populate the columns.
         """
         super().__init__()
         self.repository: SongRepository = repository
         self.repository.songs_updated.connect(self.layoutChanged.emit)
+        self._table_tags: list[SongTag] = table_tags
+
+    @Slot()
+    def updateTableTags(self, table_tags: list[SongTag]) -> None:
+        """Updatae the tags that should be used for the columns."""
+        self._table_tags = table_tags
 
     @override
     def data(
@@ -69,7 +77,7 @@ class SongTableModel(QAbstractTableModel):
         if self.rowCount(parent) == 0:
             # NOTE: Uses 1 to keep a column for info
             return 1
-        return len(prefs.settings.table_tags)
+        return len(self._table_tags)
 
     @override
     def headerData(
@@ -85,9 +93,9 @@ class SongTableModel(QAbstractTableModel):
                 if orientation == Qt.Orientation.Vertical:
                     return None
             if orientation == Qt.Orientation.Horizontal and section < len(
-                prefs.settings.table_tags,
+                self._table_tags
             ):
-                return prefs.settings.table_tags[section].display_name
+                return self._table_tags[section].display_name
             if orientation == Qt.Orientation.Vertical and section < len(
                 self.repository,
             ):

--- a/src/music_modify/models/song_repository.py
+++ b/src/music_modify/models/song_repository.py
@@ -8,6 +8,7 @@ from os import PathLike
 from PySide6.QtCore import QObject, Signal
 
 from music_modify.custom_types import Song
+from music_modify.custom_types.songtag import SongTag
 
 
 class SongRepository(QObject):
@@ -19,9 +20,14 @@ class SongRepository(QObject):
     songs_updated: Signal = Signal()
     "Signal that is emitted whenever songs are added or removed."
 
-    def __init__(self) -> None:
+    def __init__(
+        self, all_tags: list[SongTag], table_tags: list[SongTag], display_split: str
+    ) -> None:
         """Create a `SongRepository`, with no songs added yet."""
         super().__init__()
+        self._all_tags: list[SongTag] = all_tags
+        self._table_tags: list[SongTag] = table_tags
+        self._display_split: str = display_split
         self._songs: list[Song] = []
 
     def getSong(self, index: int) -> Song | None:
@@ -52,7 +58,9 @@ class SongRepository(QObject):
     def addFile(self, file: str | PathLike[str]) -> None:
         """Add file to the list of songs, if not already present."""
         if file not in self:
-            self._songs.append(Song(file))
+            self._songs.append(
+                Song(self._all_tags, self._table_tags, self._display_split, file)
+            )
             self.songs_updated.emit()
 
     def addFiles(self, files: list[str] | list[PathLike[str]]) -> None:
@@ -65,7 +73,9 @@ class SongRepository(QObject):
         if song:
             self._songs.append(song)
         else:
-            self._songs.append(Song())
+            self._songs.append(
+                Song(self._all_tags, self._table_tags, self._display_split)
+            )
         self.songs_updated.emit()
 
     def clearFiles(self) -> None:

--- a/src/music_modify/music_modify.py
+++ b/src/music_modify/music_modify.py
@@ -24,9 +24,10 @@ def main() -> Never:
     app.setApplicationName("Music Modify")
     app.setApplicationVersion("2.0.0")
 
-    prefs.settings.configureForApplication()
+    settings = prefs.Settings()
+    settings.configureForApplication()
 
-    window = MainWindow()
+    window = MainWindow(settings)
     window.show()
     sys.exit(app.exec())
 

--- a/src/music_modify/prefs/__init__.py
+++ b/src/music_modify/prefs/__init__.py
@@ -1,13 +1,5 @@
-"""Package for managing the preferences stored for the application.
+"""Package for managing the preferences stored for the application."""
 
-To use the settings, use the global `settings` object. Note that this
-*must not* be done in the import, but at run time.
+from .prefs import Settings
 
-For example:
-```python
-from music_modify.prefs import prefs
-# some other code
-
-val = prefs.settings.some_attribute
-```
-"""
+__all__ = ["Settings"]

--- a/src/music_modify/prefs/prefs.py
+++ b/src/music_modify/prefs/prefs.py
@@ -7,7 +7,7 @@ which should be used when wanting to access user preferences.
 import logging
 from typing import ClassVar, final
 
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import QObject, QSettings, Signal
 from PySide6.QtWidgets import QApplication
 
 from music_modify.custom_types.enums import EditorType
@@ -18,15 +18,24 @@ logger = logging.getLogger(__name__)
 
 
 @final
-class Settings:
+class Settings(QObject):
     """Wrapper for QSettings that provides easier access to defined setting keys."""
 
-    def __init__(self, new_settings: QSettings | None = None) -> None:
+    split_text_entered_changed: Signal = Signal(str)
+    split_values_display_changed: Signal = Signal(str)
+    split_values_at_changed: Signal = Signal(str)
+    tags_updated: Signal = Signal()
+
+    def __init__(
+        self, new_settings: QSettings | None = None, parent: QObject | None = None
+    ) -> None:
         """Create a new Settings object.
 
         Args:
             new_settings: The settings values that should be read, if present.
+            parent: The object that determines the lifetime of the settings object.
         """
+        super().__init__(parent)
         logger.info("In init method for Settings object")
         self._settings: QSettings | None = None
 
@@ -86,6 +95,7 @@ class Settings:
     @split_text_entered.setter
     def split_text_entered(self, value: str) -> None:
         self._getQSettings().setValue("Split/split_text_entered", value)
+        self.split_text_entered_changed.emit(value)
 
     @property
     def split_values_display(self) -> str:
@@ -104,6 +114,7 @@ class Settings:
     @split_values_display.setter
     def split_values_display(self, value: str) -> None:
         self._getQSettings().setValue("Split/split_values_display", value)
+        self.split_values_display_changed.emit(value)
 
     @property
     def split_values_at(self) -> str:
@@ -122,6 +133,7 @@ class Settings:
     @split_values_at.setter
     def split_values_at(self, value: str) -> None:
         self._getQSettings().setValue("Split/split_values_at", value)
+        self.split_values_at_changed.emit(value)
 
     default_tags: ClassVar[list[TagInfo]] = [
         TagInfo(
@@ -389,6 +401,7 @@ class Settings:
     def info_tags(self, value: list[TagInfo]) -> None:
         self._table_tags_cache = None  # Invalidate cache
         self._setArray("Tags/info_tags", value)
+        self.tags_updated.emit()
 
     def _setArray(self, key: str, vals: list[TagInfo]) -> None:
         """Set the QSettings array based on the list of TagInfo.
@@ -473,6 +486,3 @@ class Settings:
         """Reset the value for the tag list back to default."""
         logger.info("Called reset tags")
         self.info_tags = Settings.default_tags
-
-
-settings = Settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,16 +9,13 @@ from os import PathLike
 from pathlib import Path
 import shutil
 import tempfile
-from unittest.mock import MagicMock
 
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 import pytest
 
-from music_modify.custom_types.enums import EditorType
 from music_modify.custom_types.songtag import SongTag
-from music_modify.custom_types.tag_info import TagInfo
-from music_modify.prefs.prefs import Settings
+from music_modify.prefs import Settings
 
 NUM_TEMP_SONGS = 3
 "The number of temp songs that should be created."
@@ -90,68 +87,10 @@ def app_info(qapp: QApplication) -> tuple[str, str, str]:
 
 
 @pytest.fixture
-def mock_settings(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-    """Fixture that mocks the values for prefs.settings."""
-    mock_settings = MagicMock()
-    mock_default_tag_info = [
-        TagInfo(
-            display_name="Track",
-            id3_key="TRCK",
-            show_in_table=True,
-            editor_type=EditorType.SingleText,
-        ),
-        TagInfo(
-            display_name="Title",
-            id3_key="TIT2",
-            show_in_table=True,
-            editor_type=EditorType.SingleText,
-        ),
-        TagInfo(
-            display_name="Artist",
-            id3_key="TPE1",
-            show_in_table=True,
-            editor_type=EditorType.MultipleText,
-        ),
-        TagInfo(
-            display_name="Album Artist",
-            id3_key="TPE2",
-            show_in_table=False,
-            editor_type=EditorType.SingleText,
-        ),
-        TagInfo(
-            display_name="Genre",
-            id3_key="TCON",
-            show_in_table=False,
-            editor_type=EditorType.MultipleText,
-        ),
-        TagInfo(
-            display_name="Involved People",
-            id3_key="TIPL",
-            show_in_table=True,
-            editor_type=EditorType.PeopleValue,
-        ),
+def table_tags() -> list[SongTag]:
+    """Fixture for tags that are used for a SongTableModel."""
+    return [
+        SongTag(display_name="Title", id3_key="TIT2"),
+        SongTag(display_name="Involved People", id3_key="TIPL"),
+        SongTag(display_name="Composer", id3_key="TCOM"),
     ]
-
-    mock_table_tags_list = [
-        SongTag(
-            display_name=ti.display_name, id3_key=ti.id3_key, editor_type=ti.editor_type
-        )
-        for ti in mock_default_tag_info
-        if ti.show_in_table
-    ]
-    mock_settings.table_tags = mock_table_tags_list
-
-    mock_all_tags_list = [
-        SongTag(
-            display_name=ti.display_name, id3_key=ti.id3_key, editor_type=ti.editor_type
-        )
-        for ti in mock_default_tag_info
-    ]
-    mock_settings.all_tags = mock_all_tags_list
-
-    mock_settings.split_values_display = "; "
-    mock_settings.split_text_entered = ","
-
-    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_settings)
-
-    return mock_settings

--- a/tests/custom_types/test_song.py
+++ b/tests/custom_types/test_song.py
@@ -10,62 +10,59 @@ import pytest
 
 from music_modify.custom_types import Song
 from music_modify.custom_types.songtag import SongTag
-from music_modify.prefs import prefs
 
 logger = logging.getLogger(__name__)
 
 
-def test_Song_init_with_None(mock_settings: MagicMock) -> None:
+def test_Song_init_with_None(table_tags: list[SongTag]) -> None:
     """Test that a Song object is created correctly when not passed a file."""
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     assert song.file is None
-    info: list[str] = ["" for _ in range(len(mock_settings.table_tags))]
+    info: list[str] = ["" for _ in range(len(table_tags))]
     assert song.display_info == info
 
 
-def test_Song_init_with_file(song_path: Path, mock_settings: MagicMock) -> None:
+def test_Song_init_with_file(song_path: Path) -> None:
     """Test that a Song object is created correctly when passed a file."""
-    song = Song(song_path)
+    song = Song([], [], "", file=song_path)
     assert song.file == song_path
     assert hasattr(song, "display_info")
     assert isinstance(song.display_info, list)
 
 
 def test_Song_columns_setTag_removeTag(
-    song_path: Path, mock_settings: MagicMock
+    song_path: Path, table_tags: list[SongTag]
 ) -> None:
     """Test that setting and then removing tags works."""
-    song = Song(song_path)
+    song = Song(table_tags, table_tags, "; ", song_path)
     song.setTag("TIT2", ["Some Title"])
-    song.setTag("TPE2", ["Some Artist"])
+    song.setTag("TCOM", ["Some Composer", "Another Composer"])
     assert song.hasTag("TIT2")
-    assert song.hasTag("TPE2")
+    assert song.hasTag("TCOM")
     song.updateInfo()
     expected_output: list[str] = []
-    for col in prefs.settings.table_tags:
+    for col in table_tags:
         if col.id3_key == "TIT2":
-            logger.info("ID3 key was TIT2")
             expected_output.append("Some Title")
-        elif col.id3_key == "TPE2":
-            logger.info("ID3 key was TPE2")
-            expected_output.append("Some Artist")
+        elif col.id3_key == "TCOM":
+            expected_output.append("Some Composer; Another Composer")
         else:
             expected_output.append("")
     assert song.display_info == expected_output
     song.removeTag("TIT2")
-    song.removeTag("TPE2")
+    song.removeTag("TCOM")
     assert not song.hasTag("TIT2")
-    assert not song.hasTag("TPE2")
+    assert not song.hasTag("TCOM")
 
 
 def test_Song_invalid_tag(
-    monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that invalid tags work correctly.
 
     They should return False for hasTag, None for getValue, and don't call removeTag.
     """
-    song = Song()
+    song = Song(table_tags, table_tags, "")
 
     mock_songtag_remove = MagicMock()
     monkeypatch.setattr(SongTag, "removeTag", mock_songtag_remove)
@@ -78,10 +75,10 @@ def test_Song_invalid_tag(
 
 
 def test_Song_save_calls_updateInfo(
-    song_path: Path, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    song_path: Path, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that saving a song updates the file and the displayed info."""
-    song = Song(song_path)
+    song = Song(table_tags, table_tags, "", song_path)
     song.setTag("TIT2", ["Some Title"])
 
     mock_save = MagicMock()
@@ -96,10 +93,10 @@ def test_Song_save_calls_updateInfo(
 
 
 def test_Song_save_calls_updateInfo_file_None(
-    monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that saving a song updates the displayed info, but doesn't save a file."""
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag("TIT2", ["Some Title"])
 
     mock_save = MagicMock()
@@ -113,9 +110,9 @@ def test_Song_save_calls_updateInfo_file_None(
     mock_update.assert_called_once()
 
 
-def test_Song_load(song_path: Path, mock_settings: MagicMock) -> None:
+def test_Song_load(song_path: Path, table_tags: list[SongTag]) -> None:
     """Test that creating a song and loading the file later still populates data."""
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     assert song.file is None
 
     song.updateInfo = MagicMock()

--- a/tests/gui/completion/test_complete_line_edit.py
+++ b/tests/gui/completion/test_complete_line_edit.py
@@ -1,7 +1,5 @@
 """Tests EnLineEdit."""
 
-# pyright: reportUnusedParameter = false
-
 from typing import cast
 from unittest.mock import MagicMock, Mock
 
@@ -13,7 +11,6 @@ from pytestqt.qtbot import QtBot
 
 from music_modify.gui.completion._complete_line_edit import EnLineEdit
 from music_modify.gui.completion._completer import Completer
-from music_modify.prefs import prefs
 
 
 def test_EnLineEdit_init(qtbot: QtBot) -> None:
@@ -266,7 +263,7 @@ def test_EnLineEdit_complete_selectFirstFalse(qtbot: QtBot) -> None:
 
 def test_EnLineEdit_updateCompletions_singleMode(qtbot: QtBot) -> None:
     """Test that single mode replaces the item when selected."""
-    line_edit = EnLineEdit(multiple=False)
+    line_edit = EnLineEdit(multiple=False, split_text_entered=",")
     qtbot.addWidget(line_edit)
 
     line_edit.setText("  hello world")
@@ -280,15 +277,11 @@ def test_EnLineEdit_updateCompletions_singleMode(qtbot: QtBot) -> None:
     line_edit.mcompleter.setCompletionPrefix.assert_called_once_with("hello")
 
 
-def test_EnLineEdit_updateCompletions_multipleMode_withSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_updateCompletions_multipleMode_withSeparator(qtbot: QtBot) -> None:
     """Test that multiple mode adds separators after the items."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("item1, item2, prefix")
     line_edit.setCursorPosition(len("item1, item2, prefix"))
@@ -301,15 +294,11 @@ def test_EnLineEdit_updateCompletions_multipleMode_withSeparator(
     line_edit.mcompleter.setCompletionPrefix.assert_called_once_with("prefix")
 
 
-def test_EnLineEdit_updateCompletions_multipleMode_noSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_updateCompletions_multipleMode_noSeparator(qtbot: QtBot) -> None:
     """Test that multiple mode doesn't add a separator when there is only one item."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("just_one_item")
     line_edit.setCursorPosition(len("just_one_item"))
@@ -322,9 +311,7 @@ def test_EnLineEdit_updateCompletions_multipleMode_noSeparator(
     line_edit.mcompleter.setCompletionPrefix.assert_called_once_with("just_one_item")
 
 
-def test_EnLineEdit_updateCompletions_emptyText(
-    qtbot: QtBot, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_updateCompletions_emptyText(qtbot: QtBot) -> None:
     """Tests updating completions with empty text."""
     line_edit = EnLineEdit()
     qtbot.addWidget(line_edit)
@@ -340,19 +327,15 @@ def test_EnLineEdit_updateCompletions_emptyText(
     line_edit.mcompleter.setCompletionPrefix.assert_called_once_with("")
 
 
-def test_EnLineEdit_updateCompletions_cursorInMiddle(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_updateCompletions_cursorInMiddle(qtbot: QtBot) -> None:
     """Tests that completions are added when updating and the cursor is in the middle.
 
     The completed item should be added, and a separator put after it,
     which will split the original item.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ";"
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("first; second; third")
     line_edit.setCursorPosition(len("first; sec"))  # Cursor after 'sec' in 'second'
@@ -375,15 +358,11 @@ def test_EnLineEdit_getCompletedText_singleMode(qtbot: QtBot) -> None:
     assert after_text == ""
 
 
-def test_EnLineEdit_getCompletedText_multipleMode_emptyLineEdit(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_getCompletedText_multipleMode_emptyLineEdit(qtbot: QtBot) -> None:
     """Tests that selecting the first entry in multiple mode adds a separator after."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = "|"
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("")
     line_edit.setCursorPosition(0)
@@ -394,14 +373,12 @@ def test_EnLineEdit_getCompletedText_multipleMode_emptyLineEdit(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_noOriginalCursorPos(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot,
 ) -> None:
     """Tests that cursorPosition is used if there is no original cursor position."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("item1, prefix, suffix")
     line_edit.setCursorPosition(len("item1, prefix"))  # Cursor after 'prefix'
@@ -415,14 +392,12 @@ def test_EnLineEdit_getCompletedText_multipleMode_noOriginalCursorPos(
 
 
 def test_EnLineEdit_getCompletedText_multipleMode_withOriginalCursorPos(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot,
 ) -> None:
     """Tests that the original cursor position is used if it exists."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ";"
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("alpha; beta; gamma")
     line_edit.original_cursor_pos = len(
@@ -435,18 +410,14 @@ def test_EnLineEdit_getCompletedText_multipleMode_withOriginalCursorPos(
     assert line_edit.original_cursor_pos is None  # Should be reset
 
 
-def test_EnLineEdit_getCompletedText_multipleMode_cursorAtEnd(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_getCompletedText_multipleMode_cursorAtEnd(qtbot: QtBot) -> None:
     """Tests that an item is appened when the cursor is at the end.
 
     Ensures that a separator is still added.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("words, are, here, and, the")
     line_edit.setCursorPosition(len("words, are, here, and, the"))
@@ -456,19 +427,15 @@ def test_EnLineEdit_getCompletedText_multipleMode_cursorAtEnd(
     assert after == ""
 
 
-def test_EnLineEdit_getCompletedText_multipleMode_cursorAtStart(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_getCompletedText_multipleMode_cursorAtStart(qtbot: QtBot) -> None:
     """Tests that adding an item at the start adds it.
 
     There still needs to be a separator after the item added,
     that is before the original items in the list.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("suffix_only")
     line_edit.setCursorPosition(0)
@@ -580,18 +547,14 @@ def test_EnLineEdit_applyCurrentText_singleMode(qtbot: QtBot) -> None:
     line_edit.completionSelected.assert_not_called()
 
 
-def test_EnLineEdit_applyCurrentText_multipleMode_withSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_applyCurrentText_multipleMode_withSeparator(qtbot: QtBot) -> None:
     """Tests applying text in multiple mode when an item is selected after a separator.
 
     The item that is selected should be added, and completionSelected should be called.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("item1, item2, new_item ")
     line_edit.setCursorPosition(len("item1, item2, new_item "))
@@ -603,19 +566,15 @@ def test_EnLineEdit_applyCurrentText_multipleMode_withSeparator(
     line_edit.completionSelected.assert_called_once_with("new_item")
 
 
-def test_EnLineEdit_applyCurrentText_multipleMode_noSeparator(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
-) -> None:
+def test_EnLineEdit_applyCurrentText_multipleMode_noSeparator(qtbot: QtBot) -> None:
     """Tests applying the text when there is a single item with no separator.
 
     This value isn't in the completer items, so it's not found,
     but completionSelected should be called.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ","
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("single_item_no_separator")
     line_edit.setCursorPosition(len("single_item_no_separator"))
@@ -630,14 +589,12 @@ def test_EnLineEdit_applyCurrentText_multipleMode_noSeparator(
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_emptyText(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot,
 ) -> None:
     """Tests applying the text when there are no items, only empty text."""
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = ";"
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("")
     line_edit.setCursorPosition(0)
@@ -651,18 +608,16 @@ def test_EnLineEdit_applyCurrentText_multipleMode_emptyText(
 
 
 def test_EnLineEdit_applyCurrentText_multipleMode_separatorAtStart(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot,
 ) -> None:
     """Tests applying current text when cursor is right after separator.
 
     In this case, the user hasn't entered anything,
     so there are no completion items, so completionSelected should not be called.
     """
-    line_edit = EnLineEdit(multiple=True)
-    qtbot.addWidget(line_edit)
-
     test_separator = "|"
-    monkeypatch.setattr(prefs.settings, "split_text_entered", test_separator)
+    line_edit = EnLineEdit(multiple=True, split_text_entered=test_separator)
+    qtbot.addWidget(line_edit)
 
     line_edit.setText("| item")
     line_edit.setCursorPosition(len("| item"))

--- a/tests/gui/edit/bulk/test_dialog_edit_bulk.py
+++ b/tests/gui/edit/bulk/test_dialog_edit_bulk.py
@@ -1,6 +1,6 @@
 """Tests for EditBulkDialog."""
 
-# pyright: reportPrivateUsage = false, reportUnusedParameter = false
+# pyright: reportPrivateUsage = false
 
 import logging
 from typing import cast
@@ -36,20 +36,20 @@ def test_addSingleValues() -> None:
 
 
 def test_EditBulkDialog_updateSongInfo_no_changes(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Tests that save is not called if no changes were made to the song."""
     parent = QWidget()
     qtbot.addWidget(parent)
 
-    song_1 = Song()
+    song_1 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_1, "save", Mock())
-    song_2 = Song()
+    song_2 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_2, "save", Mock())
 
-    repo = SongRepository()
-    repo.addSong()
-    repo.addSong()
+    repo = SongRepository(table_tags, table_tags, ", ")
+    repo.addSong(song_1)
+    repo.addSong(song_2)
     rows = [0, 1]
 
     mock_widget_1 = Mock()
@@ -57,7 +57,7 @@ def test_EditBulkDialog_updateSongInfo_no_changes(
     mock_widget_2 = Mock()
     mock_widget_2.updateTag.return_value = set()
 
-    dialog = EditBulkDialog(parent, repo, rows)
+    dialog = EditBulkDialog(parent, repo, rows, ", ", table_tags)
     # NOTE: DO NOT ADD to qtbot, leads to crash
 
     monkeypatch.setattr(
@@ -75,18 +75,18 @@ def test_EditBulkDialog_updateSongInfo_no_changes(
 
 
 def test_EditBulkDialog_updateSongInfo_with_changes(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that save is called with the updated changes."""
     parent = QWidget()
     qtbot.addWidget(parent)
 
-    song_1 = Song()
+    song_1 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_1, "save", Mock())
-    song_2 = Song()
+    song_2 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_2, "save", Mock())
 
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addSong(song_1)
     repo.addSong(song_2)
     rows = [0, 1]
@@ -96,7 +96,9 @@ def test_EditBulkDialog_updateSongInfo_with_changes(
     mock_widget_2 = Mock()
     mock_widget_2.updateTag.return_value = {song_2}
 
-    dialog = EditBulkDialog(parent, repo, rows)
+    dialog = EditBulkDialog(
+        parent, repo, rows, split_text_entered=",", all_tags=table_tags
+    )
     # NOTE: DO NOT ADD to qtbot, leads to crash
 
     assert song_1 in dialog.songs
@@ -117,18 +119,18 @@ def test_EditBulkDialog_updateSongInfo_with_changes(
 
 
 def test_EditBulkDialog_updateSongInfo_with_changes_single(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that save is only called for songs that actually change data."""
     parent = QWidget()
     qtbot.addWidget(parent)
 
-    song_1 = Song()
+    song_1 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_1, "save", Mock())
-    song_2 = Song()
+    song_2 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_2, "save", Mock())
 
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addSong(song_1)
     repo.addSong(song_2)
     rows = [0, 1]
@@ -138,7 +140,7 @@ def test_EditBulkDialog_updateSongInfo_with_changes_single(
     mock_widget_2 = Mock()
     mock_widget_2.updateTag.return_value = {song_2}
 
-    dialog = EditBulkDialog(parent, repo, rows)
+    dialog = EditBulkDialog(parent, repo, rows, ",", table_tags)
     # NOTE: DO NOT ADD to qtbot, leads to crash
 
     assert song_1 in dialog.songs
@@ -159,23 +161,23 @@ def test_EditBulkDialog_updateSongInfo_with_changes_single(
 
 
 def test_EditBulkDialog_updateSongInfo_no_widgets(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Tests that save is not called, without mocking widgets."""
     parent = QWidget()
     qtbot.addWidget(parent)
 
-    song_1 = Song()
+    song_1 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_1, "save", Mock())
-    song_2 = Song()
+    song_2 = Song(table_tags, table_tags, ", ")
     monkeypatch.setattr(song_2, "save", Mock())
 
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addSong(song_1)
     repo.addSong(song_2)
     rows = [0, 1]
 
-    dialog = EditBulkDialog(parent, repo, rows)
+    dialog = EditBulkDialog(parent, repo, rows, ", ", table_tags)
     # NOTE: DO NOT ADD to qtbot, leads to crash
 
     assert song_1 in dialog.songs
@@ -191,32 +193,25 @@ def test_EditBulkDialog_updateSongInfo_no_widgets(
 
 
 def test_EditBulkDialog_setupSongInfo_unsupported_editor_type_logged(
-    monkeypatch: pytest.MonkeyPatch, qtbot: QtBot, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that _setupSongInfo logs unsupported EditorType."""
     widget = QWidget()
     qtbot.addWidget(widget)
-
-    mock_repository = MagicMock(spec=SongRepository)
-    mock_song = MagicMock()
-    mock_song.id3 = "dummy_id3"
-    mock_repository.__getitem__.return_value = mock_song
-    rows = [0]
 
     mock_tag = MagicMock(spec=SongTag)
     mock_tag.editor_type = EditorType.Automatic
     mock_tag.getValue.return_value = None
     mock_tag.display_name = "Automatic Tag"
 
-    mock_prefs_settings = MagicMock()
-    mock_prefs_settings.all_tags = [mock_tag]
-    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_prefs_settings)
+    repo = SongRepository([mock_tag], [mock_tag], ", ")
+    repo.addSong()
+    rows = [0]
 
     with caplog.at_level(logging.WARNING):
-        EditBulkDialog(widget, mock_repository, rows)
+        EditBulkDialog(widget, repo, rows, split_text_entered=", ", all_tags=[mock_tag])
 
-        assert (
-            f"editor_type had an unsupported value: {EditorType.Automatic}"
-            in caplog.text
-        )
-        assert caplog.records[0].levelname == "WARNING"
+    assert (
+        f"editor_type had an unsupported value: {EditorType.Automatic}" in caplog.text
+    )
+    assert caplog.records[0].levelname == "WARNING"

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_line.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_line.py
@@ -1,9 +1,5 @@
 """Tests for EditBulkLineWidget."""
 
-# pyright: reportUnusedParameter = false
-
-from unittest.mock import MagicMock
-
 from PySide6.QtWidgets import QWidget
 from pytestqt.qtbot import QtBot
 
@@ -23,7 +19,7 @@ def test_EditBulkLineWidget_init_not_in_all(qtbot: QtBot) -> None:
     tag = SongTag(display_name="Album", id3_key="TALB")
     data = {"First", "Second"}
 
-    widget = EditBulkLineWidget(parent, data, tag, in_all=False)
+    widget = EditBulkLineWidget(parent, data, tag, in_all=False, split_text_entered="")
     qtbot.addWidget(widget)
     assert "First" in widget.items
     assert "Second" in widget.items
@@ -49,7 +45,7 @@ def test_EditBulkLineWidget_init_in_all(qtbot: QtBot) -> None:
     tag = SongTag(display_name="Album", id3_key="TALB")
     data = {"First"}
 
-    widget = EditBulkLineWidget(parent, data, tag, in_all=True)
+    widget = EditBulkLineWidget(parent, data, tag, in_all=True, split_text_entered="")
     qtbot.addWidget(widget)
     assert widget.items == ("First",)
 
@@ -66,7 +62,7 @@ def _createWidget(qtbot: QtBot) -> tuple[QWidget, SongTag, EditBulkLineWidget]:
     tag = SongTag(display_name="Album", id3_key="TALB")
     data = {"First"}
 
-    widget = EditBulkLineWidget(parent, data, tag, in_all=True)
+    widget = EditBulkLineWidget(parent, data, tag, in_all=True, split_text_entered="")
     qtbot.addWidget(widget)
 
     return parent, tag, widget
@@ -125,7 +121,7 @@ def test_EditBulkLineWidget_updateTag_clear_no_songs(qtbot: QtBot) -> None:
 
 
 def test_EditBulkLineWidget_updateTag_apply_empty_clears(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that updateTag clears the tag if apply is called with an empty widget."""
     _, tag, widget = _createWidget(qtbot)
@@ -133,7 +129,7 @@ def test_EditBulkLineWidget_updateTag_apply_empty_clears(
     widget.clear_checkbox.setChecked(False)
     widget.apply_checkbox.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, ["First"])
     assert song.hasTag(tag)
     widget.main_widget.setText("")
@@ -143,7 +139,7 @@ def test_EditBulkLineWidget_updateTag_apply_empty_clears(
 
 
 def test_EditBulkLineWidget_updateTag_apply_only_space_clears(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that updateTag clears tag if apply called with widget having only space."""
     _, tag, widget = _createWidget(qtbot)
@@ -151,7 +147,7 @@ def test_EditBulkLineWidget_updateTag_apply_only_space_clears(
     widget.clear_checkbox.setChecked(False)
     widget.apply_checkbox.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, ["First"])
     assert song.hasTag(tag)
     widget.main_widget.setText("     ")
@@ -161,7 +157,7 @@ def test_EditBulkLineWidget_updateTag_apply_only_space_clears(
 
 
 def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that calling update when not empty sets the tag value."""
     _, tag, widget = _createWidget(qtbot)
@@ -169,7 +165,7 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(
     widget.clear_checkbox.setChecked(False)
     widget.apply_checkbox.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, ["First"])
     assert song.hasTag(tag)
 
@@ -184,7 +180,7 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets(
 
 
 def test_EditBulkLineWidget_updateTag_apply_not_empty_sets_stripped(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that calling update when not empty sets the tag value without whitespace."""
     _, tag, widget = _createWidget(qtbot)
@@ -192,7 +188,7 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets_stripped(
     widget.clear_checkbox.setChecked(False)
     widget.apply_checkbox.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, ["First"])
     assert song.hasTag(tag)
 
@@ -207,7 +203,7 @@ def test_EditBulkLineWidget_updateTag_apply_not_empty_sets_stripped(
 
 
 def test_EditBulkLineWidget_updateTag_clear(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that clearing works when clear checkbox checked and updating."""
     _, tag, widget = _createWidget(qtbot)
@@ -217,7 +213,7 @@ def test_EditBulkLineWidget_updateTag_clear(
     widget.apply_checkbox.setChecked(False)
     widget.clear_checkbox.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, ["First"])
     assert song.hasTag(tag)
 

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_multiple.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_multiple.py
@@ -3,7 +3,6 @@
 # pyright: reportPrivateUsage = false, reportUnusedParameter = false
 
 from typing import NotRequired, TypedDict
-from unittest.mock import MagicMock, Mock
 
 from PySide6.QtWidgets import QWidget
 import pytest
@@ -20,10 +19,7 @@ from music_modify.gui.edit.bulk.widget_edit_bulk_multiple import (
 def test_MultipleLineEdit_items(qtbot: QtBot, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tests that items are set properly for a _MultipleLineEdit."""
     text_to_split = "First, Second, Third"
-    mock_prefs_settings = Mock()
-    mock_prefs_settings.split_text_entered = ","
-    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_prefs_settings)
-    line_edit = _MultipleLineEdit(text_to_split)
+    line_edit = _MultipleLineEdit(text_to_split, ", ")
     qtbot.addWidget(line_edit)
     assert line_edit.items == ["First", "Second", "Third"]
 
@@ -32,7 +28,7 @@ def test_EditBulkMultipleWidget_init_not_empty(qtbot: QtBot) -> None:
     """Test creating an EditBulkMultipleWidget when data is not empty."""
     parent = QWidget()
     tag = SongTag(display_name="Composer", id3_key="TCOM")
-    widget = EditBulkMultipleWidget(parent, {"One"}, tag)
+    widget = EditBulkMultipleWidget(parent, {"One"}, tag, ", ")
     qtbot.addWidget(widget)
 
     assert widget.items == ("One",)
@@ -53,7 +49,7 @@ def _createWidget(
         items = set()
     parent = QWidget()
     tag = SongTag(display_name="Composer", id3_key="TCOM")
-    widget = EditBulkMultipleWidget(parent, items, tag)
+    widget = EditBulkMultipleWidget(parent, items, tag, ", ")
     qtbot.addWidget(widget)
 
     return parent, tag, widget
@@ -73,9 +69,7 @@ def test_EditBulkMultipleWidget_updateTag_group_box_unchecked(
     assert not widget.updateTag(songs)
 
 
-def test_EditBulkMultipleWidget_adds_to_line(
-    qtbot: QtBot, mock_settings: MagicMock
-) -> None:
+def test_EditBulkMultipleWidget_adds_to_line(qtbot: QtBot) -> None:
     """Tests typing a value in the lines updates line values, but not widget ones.
 
     The widget should only store the values actually stored in all the songs.
@@ -93,16 +87,16 @@ def test_EditBulkMultipleWidget_adds_to_line(
 
 
 def test_EditBulkMultipleWidget_updateTag_clear_checkbox_checked(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that tags are removed if updateTag is called with clear checked."""
     _, tag, widget = _createWidget(qtbot)
 
     widget.group_box.setChecked(True)
 
-    song1 = Song()
+    song1 = Song(table_tags, table_tags, ", ")
     song1.setTag(tag, ["One Composer"])
-    song2 = Song()
+    song2 = Song(table_tags, table_tags, ", ")
     song2.setTag(tag, ["One Composer", "Another Composer"])
     songs = [song1, song2]
 
@@ -114,16 +108,16 @@ def test_EditBulkMultipleWidget_updateTag_clear_checkbox_checked(
 
 
 def test_EditBulkMultipleWidget_updateTag_empty_add_empty_remove(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests adding or removing empty values doesn't change the song value."""
     _, tag, widget = _createWidget(qtbot)
 
     widget.group_box.setChecked(True)
 
-    song1 = Song()
+    song1 = Song(table_tags, table_tags, ", ")
     song1.setTag(tag, ["One Composer"])
-    song2 = Song()
+    song2 = Song(table_tags, table_tags, ", ")
     song2.setTag(tag, ["One Composer", "Another Composer"])
     songs = [song1, song2]
 
@@ -139,14 +133,14 @@ def test_EditBulkMultipleWidget_updateTag_empty_add_empty_remove(
 
 
 def test_EditBulkMultipleWidget_updateTag_single_song_empty_add(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests adding values to a song that doesn't have the tag at start."""
     _, tag, widget = _createWidget(qtbot)
 
     widget.group_box.setChecked(True)
 
-    song1 = Song()
+    song1 = Song(table_tags, table_tags, ", ")
 
     assert widget.items == ()
     assert widget.remove_line.all_items == ()
@@ -164,14 +158,14 @@ def test_EditBulkMultipleWidget_updateTag_single_song_empty_add(
 
 
 def test_EditBulkMultipleWidget_updateTag_single_song_and_widget_same(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that setting text for adding a value already present doesn't add it."""
     _, tag, widget = _createWidget(qtbot)
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     song.setTag(tag, ["Some Name", "And Another"])
     songs = [song]
 
@@ -185,7 +179,7 @@ def test_EditBulkMultipleWidget_updateTag_single_song_and_widget_same(
 
 
 def test_EditBulkMultipleWidget_updateTag_single_widget_has_extra(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that any items not in the song are correctly added.
 
@@ -196,7 +190,7 @@ def test_EditBulkMultipleWidget_updateTag_single_widget_has_extra(
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     song.setTag(tag, ["Some Name"])
 
     assert isinstance(song.getValue(tag), list)
@@ -267,14 +261,14 @@ def test_EditBulkMultipleWidget_updateTag_songs_param(
     value: list[str] | None,
     expected_updated: bool,
     expected_value: list[str],
-    mock_settings: MagicMock,
+    table_tags: list[SongTag],
 ) -> None:
     """Tests that updateTag changes values that it should."""
     _, tag, widget = _createWidget(qtbot)
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     if value is not None:
         song.setTag(tag, value)
     songs: list[Song] = [song]
@@ -289,7 +283,7 @@ def test_EditBulkMultipleWidget_updateTag_songs_param(
 
 
 def test_EditBulkMultipleWidget_updateTag_multiple_add(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests adding values to multiple songs, with different conditions."""
     _, tag, widget = _createWidget(qtbot)
@@ -300,7 +294,7 @@ def test_EditBulkMultipleWidget_updateTag_multiple_add(
     expected_final_values: list[list[str]] = []
 
     for case in _SONG_CASES:
-        song = Song()
+        song = Song(table_tags, table_tags, ", ")
         if (value := case["initial_value"]) is not None:
             song.setTag(tag, value)
         songs.append(song)
@@ -317,7 +311,7 @@ def test_EditBulkMultipleWidget_updateTag_multiple_add(
 
 
 def test_EditBulkMultipleWidget_updateTag_song_empty_remove(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that removing tag values for songs that don't have that tag works.
 
@@ -327,7 +321,7 @@ def test_EditBulkMultipleWidget_updateTag_song_empty_remove(
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     assert not song.hasTag(tag)
 
     widget.remove_line.setText("First Name")
@@ -394,7 +388,7 @@ def test_EditBulkMultipleWidget_updateTag_remove_param(
     widget_text: str,
     expected_updated: bool,
     expected_final_value: list[str],
-    mock_settings: MagicMock,
+    table_tags: list[SongTag],
 ) -> None:
     """Tests removing tag values in different conditions.
 
@@ -409,7 +403,7 @@ def test_EditBulkMultipleWidget_updateTag_remove_param(
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     song.setTag(tag, song_initial_values)
 
     widget.remove_line.setText(widget_text)
@@ -420,7 +414,7 @@ def test_EditBulkMultipleWidget_updateTag_remove_param(
 
 
 def test_EditBulkMultipleWidget_updateTag_add_remove(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that both adding and removing values works if done together.
 
@@ -430,7 +424,7 @@ def test_EditBulkMultipleWidget_updateTag_add_remove(
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     song.setTag(tag, ["Song Value", "Extra Value"])
 
     widget.add_line.setText("New Value, And Another, Removed")
@@ -444,14 +438,14 @@ def test_EditBulkMultipleWidget_updateTag_add_remove(
 
 
 def test_EditBulkMultipleWidget_resetView(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that resetView restores the original state for the widget."""
     _, tag, widget = _createWidget(qtbot, set())
 
     widget.group_box.setChecked(True)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ", ")
     song.setTag(tag, ["Song Value", "Extra Value"])
 
     widget.add_line.setText("Another Value")

--- a/tests/gui/edit/bulk/test_widget_edit_bulk_people.py
+++ b/tests/gui/edit/bulk/test_widget_edit_bulk_people.py
@@ -131,7 +131,7 @@ change_params: list[_ChangeParams] = [
     ],
 )
 def test_ActionMapping_performChange_param(
-    qtbot: QtBot, change_param: _ChangeParams, mock_settings: MagicMock
+    qtbot: QtBot, change_param: _ChangeParams, table_tags: list[SongTag]
 ) -> None:
     """Tests how performChange works based on different inputs.
 
@@ -150,7 +150,7 @@ def test_ActionMapping_performChange_param(
 
     _, tag, widget = _createWidget(qtbot, widget_items)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     if song_items is not None:
         song.setTag(tag, song_items)
 
@@ -246,15 +246,15 @@ def test_EditBulkPeopleWidget_updateTag_unchecked(qtbot: QtBot) -> None:
 
 
 def test_EditBulkPeopleWidget_updateTag_clear_checkbox_checked(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that values are cleared when updateTag is called with clear checked."""
     initial_data = [["Role 1", "Person 1"]]
     _, tag, widget = _createWidget(qtbot, initial_data)
 
-    song1 = Song()
+    song1 = Song(table_tags, table_tags, "")
     song1.setTag(tag, initial_data)
-    song2 = Song()
+    song2 = Song(table_tags, table_tags, "")
     song2.setTag(tag, initial_data)
     songs = [song1, song2]
 
@@ -271,13 +271,13 @@ def test_EditBulkPeopleWidget_updateTag_clear_checkbox_checked(
 
 
 def test_EditBulkPeopleWidget_updateTag_no_changes_attempted(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that updateTag isn't called when there are no changes."""
     widget_data = []
     _, tag, widget = _createWidget(qtbot, widget_data)
 
-    song = Song()
+    song = Song(table_tags, table_tags, ",")
     assert not song.hasTag(tag)
     songs = [song]
 
@@ -535,7 +535,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_param(
     widget_name: str,
     widget_items: list[str] | list[list[str]],
     song_infos: list[_SongInfo],
-    mock_settings: MagicMock,
+    table_tags: list[SongTag],
 ) -> None:
     """Test updating tag based on the widget details."""
     widget_data = []
@@ -545,7 +545,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_param(
     expected_updated_songs: set[Song] = set()
     expected_song_values: list[list[list[str]]] = []
     for info in song_infos:
-        song = Song()
+        song = Song(table_tags, table_tags, "")
         song.setTag(tag, info["items"])
         songs.append(song)
         if info["updated"]:
@@ -578,13 +578,13 @@ def test_EditBulkPeopleWidget_updateTag_single_param(
     widget_name: str,
     widget_items: list[str] | list[list[str]],
     info: _SongInfo,
-    mock_settings: MagicMock,
+    table_tags: list[SongTag],
 ) -> None:
     """Tests updating tags for a single song, based on the widget details."""
     widget_data = []
     _, tag, widget = _createWidget(qtbot, widget_data)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     song.setTag(tag, info["items"])
 
     expected_update_result: set[Song] = {song} if info["updated"] else set()
@@ -602,7 +602,7 @@ def test_EditBulkPeopleWidget_updateTag_single_param(
 
 
 def test_EditBulkPeopleWidget_updateTag_multiple_actions(
-    qtbot: QtBot, mock_settings: MagicMock
+    qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests calling updateTag with multiple fields filled."""
     initial_widget_items = [
@@ -611,7 +611,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_actions(
     ]
     _, tag, widget = _createWidget(qtbot, initial_widget_items)
 
-    song = Song()
+    song = Song(table_tags, table_tags, "")
     # Initial state of song: contains an existing item, one to be removed by pair,
     # one by role, one by person,
     # one whose role will be remapped, one whose person will be remapped.
@@ -662,7 +662,7 @@ def test_EditBulkPeopleWidget_updateTag_multiple_actions(
 
 
 def test_EditBulkPeopleWidget_resetView(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Tests that the people widget re-displays the original values on reset."""
     initial_widget_data = [["Role1", "Person1"], ["Role2", "Person2"]]

--- a/tests/gui/edit/test_dialog_edit.py
+++ b/tests/gui/edit/test_dialog_edit.py
@@ -1,16 +1,16 @@
 """Tests for EditDialog."""
 
-# pyright: reportPrivateUsage = false, reportUnusedParameter = false
+# pyright: reportPrivateUsage = false
 
 import logging
 from typing import cast
-from unittest.mock import MagicMock, Mock, PropertyMock
+from unittest.mock import Mock, PropertyMock
 
 from PySide6.QtWidgets import QDialog, QWidget
 import pytest
 from pytestqt.qtbot import QtBot
 
-from music_modify.custom_types.enums import EditorType, NavDirection
+from music_modify.custom_types.enums import NavDirection
 from music_modify.custom_types.song import Song
 from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.dialog_edit import EditDialog
@@ -19,39 +19,41 @@ from music_modify.models.song_repository import SongRepository
 
 
 def _createParentAndRepo(
-    qtbot: QtBot, num_songs: int = 0
+    qtbot: QtBot,
+    table_tags: list[SongTag],
+    num_songs: int = 0,
 ) -> tuple[QWidget, SongRepository]:
     widget = QWidget()
     qtbot.addWidget(widget)
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     for _ in range(num_songs):
         repo.addSong()
     return widget, repo
 
 
 def _createDialog(
-    qtbot: QtBot, rows: list[int], *, num_songs: int = 0
+    qtbot: QtBot, rows: list[int], table_tags: list[SongTag], *, num_songs: int = 0
 ) -> tuple[QWidget, EditDialog]:
-    widget, repo = _createParentAndRepo(qtbot, num_songs)
-    dialog = EditDialog(widget, repo, rows)
+    widget, repo = _createParentAndRepo(qtbot, table_tags, num_songs)
+    dialog = EditDialog(widget, repo, rows, table_tags)
     return widget, dialog
 
 
-def test_EditDialog_init_no_rows(qtbot: QtBot) -> None:
+def test_EditDialog_init_no_rows(qtbot: QtBot, table_tags: list[SongTag]) -> None:
     """Tests that passing no rows through rejects the dialog."""
-    _, dialog = _createDialog(qtbot, [], num_songs=0)
+    _, dialog = _createDialog(qtbot, [], table_tags, num_songs=0)
     assert dialog.result() == QDialog.DialogCode.Rejected
 
 
-def test_EditDialog_init_song_None(qtbot: QtBot) -> None:
+def test_EditDialog_init_song_None(qtbot: QtBot, table_tags: list[SongTag]) -> None:
     """Tests that the dialog is rejected if there is no song at that index."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=0)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=0)
     assert dialog.result() == QDialog.DialogCode.Rejected
 
 
-def test_EditDialog_init_song_single(qtbot: QtBot, mock_settings: MagicMock) -> None:
+def test_EditDialog_init_song_single(qtbot: QtBot, table_tags: list[SongTag]) -> None:
     """Tests that the song is found at the index, and nav buttons aren't created."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=1)
 
     assert dialog.song_info is not None
     assert isinstance(dialog.song_info, Song)
@@ -60,9 +62,9 @@ def test_EditDialog_init_song_single(qtbot: QtBot, mock_settings: MagicMock) -> 
     assert not hasattr(dialog, "next_button")
 
 
-def test_EditDialog_init_song_multiple(qtbot: QtBot, mock_settings: MagicMock) -> None:
+def test_EditDialog_init_song_multiple(qtbot: QtBot, table_tags: list[SongTag]) -> None:
     """Tests that the songs are found at the indexes, and nav buttons are created."""
-    _, dialog = _createDialog(qtbot, [0, 1], num_songs=2)
+    _, dialog = _createDialog(qtbot, [0, 1], table_tags, num_songs=2)
 
     assert dialog.song_info is not None
     assert isinstance(dialog.song_info, Song)
@@ -92,10 +94,10 @@ def test_EditDialog_init_song_multiple(qtbot: QtBot, mock_settings: MagicMock) -
 
 
 def test_EditDialog_updateSongInfo_setsValue(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Tests that calling updateSongInfo saves the values to the song."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=1)
 
     mock_tag = Mock(spec=SongTag)
     test_key: str = "TIT2"
@@ -123,10 +125,10 @@ def test_EditDialog_updateSongInfo_setsValue(
 
 
 def test_EditDialog_updateSongInfo_removesValue(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Tests that calling updateSongInfo removes values when needed."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=1)
 
     mock_tag = Mock(spec=SongTag)
     test_key: str = "TPE1"
@@ -157,10 +159,10 @@ def test_EditDialog_updateSongInfo_unknownTag(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
-    mock_settings: MagicMock,
+    table_tags: list[SongTag],
 ) -> None:
     """Tests that updating an unknown tag logs, and doesn't save."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=1)
 
     mock_tag = Mock(spec=SongTag)
     test_key: str = "TPE1"
@@ -194,10 +196,10 @@ def test_EditDialog_updateSongInfo_unknownTag(
 
 
 def test_EditDialog_switchButtonState_no_buttons_logged(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot, table_tags: list[SongTag], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Tests logging when trying to change button state for non-existing buttons."""
-    _, dialog = _createDialog(qtbot, [], num_songs=0)
+    _, dialog = _createDialog(qtbot, [], table_tags, num_songs=0)
 
     assert not hasattr(dialog, "next_button")
     assert not hasattr(dialog, "previous_button")
@@ -210,10 +212,10 @@ def test_EditDialog_switchButtonState_no_buttons_logged(
 
 
 def test_EditDialog_showSongInDirection_last_or_first_logged(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture, mock_settings: MagicMock
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture, table_tags: list[SongTag]
 ) -> None:
     """Tests that invalid navigation on first or last is logged."""
-    _, dialog = _createDialog(qtbot, [0, 1], num_songs=2)
+    _, dialog = _createDialog(qtbot, [0, 1], table_tags, num_songs=2)
 
     assert dialog.current_index == 0
 
@@ -238,10 +240,10 @@ def test_EditDialog_showSongInDirection_last_or_first_logged(
 
 
 def test_EditDialog_showSongInDirection_no_song(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture, mock_settings: MagicMock
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture, table_tags: list[SongTag]
 ) -> None:
     """Tests that trying to display a song at an invalid index closes the dialog."""
-    _, dialog = _createDialog(qtbot, [0, 1], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0, 1], table_tags, num_songs=1)
 
     with caplog.at_level(logging.WARNING):
         dialog.showSongInDirection(NavDirection.Next)
@@ -251,50 +253,33 @@ def test_EditDialog_showSongInDirection_no_song(
 
 
 def test_EditDialog_resetSongInfo(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Tests that the song values can be reset."""
-    widget, repo = _createParentAndRepo(qtbot, 1)
+    widget, repo = _createParentAndRepo(qtbot, table_tags, 1)
     rows: list[int] = [0]
-
-    mock_tag1 = Mock(spec=SongTag)
-    mock_tag1.display_name = "Artist"
-    mock_tag1.getValue.return_value = "Test Artist"
-    mock_tag1.id3_key = "TPE1"
-    mock_tag1.editor_type = EditorType.MultipleText
-
-    mock_tag2 = Mock(spec=SongTag)
-    mock_tag2.display_name = "Title"
-    mock_tag2.getValue.return_value = "Test Title"
-    mock_tag2.id3_key = "TIT2"
-    mock_tag2.editor_type = EditorType.SingleText
-
-    mock_all_tags = [mock_tag1, mock_tag2]
-    mock_prefs_settings = Mock()
-    mock_prefs_settings.all_tags = mock_all_tags
-    monkeypatch.setattr("music_modify.prefs.prefs.settings", mock_prefs_settings)
 
     mock_reset_method = Mock()
     monkeypatch.setattr(EditAbstractWidget, "reset", mock_reset_method)
 
-    dialog = EditDialog(widget, repo, rows)
+    dialog = EditDialog(widget, repo, rows, table_tags)
     qtbot.addWidget(dialog)
 
     found_widgets = dialog.findChildren(EditAbstractWidget)
-    assert len(found_widgets) == len(mock_all_tags)
+    assert len(found_widgets) == len(table_tags)
     mock_reset_method.assert_not_called()
 
     dialog.resetSongInfo()
 
-    assert mock_reset_method.call_count == len(mock_all_tags)
+    assert mock_reset_method.call_count == len(table_tags)
 
 
 @pytest.fixture
 def edit_dialog_mocks(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, mock_settings: MagicMock
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> tuple[EditDialog, Mock, Mock, PropertyMock]:
     """Fixture for creating multiple mocks for EditDialogs."""
-    _, dialog = _createDialog(qtbot, [0], num_songs=1)
+    _, dialog = _createDialog(qtbot, [0], table_tags, num_songs=1)
 
     mock_tag = Mock(spec=SongTag)
     mock_tag.id3_key = "TEST"

--- a/tests/gui/edit/test_dialog_edit_factory.py
+++ b/tests/gui/edit/test_dialog_edit_factory.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import QWidget
 import pytest
 from pytestqt.qtbot import QtBot
 
+from music_modify.custom_types.songtag import SongTag
 from music_modify.gui.edit.bulk.dialog_edit_bulk import EditBulkDialog
 from music_modify.gui.edit.dialog_edit import EditDialog
 from music_modify.gui.edit.dialog_edit_factory import EditDialogFactory
@@ -13,14 +14,16 @@ from music_modify.models.song_repository import SongRepository
 @pytest.mark.parametrize(
     "bulk", [pytest.param(False, id="not_bulk"), pytest.param(True, id="bulk")]
 )
-def test_EditDialogFactory_get(qtbot: QtBot, bulk: bool) -> None:
+def test_EditDialogFactory_get(
+    qtbot: QtBot, bulk: bool, table_tags: list[SongTag]
+) -> None:
     """Test that the correct dialog type is returned, based on bulk."""
     widget = QWidget()
     qtbot.addWidget(widget)
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     factory = EditDialogFactory(widget, repo)
 
-    dialog = factory.get([], bulk=bulk)
+    dialog = factory.get([], table_tags, ", ", bulk=bulk)
     expected_type = EditBulkDialog if bulk else EditDialog
     qtbot.addWidget(dialog)
     assert isinstance(dialog, expected_type)

--- a/tests/gui/edit/test_widget_edit_factory.py
+++ b/tests/gui/edit/test_widget_edit_factory.py
@@ -15,7 +15,7 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
 
 
 @pytest.mark.parametrize(
-    ("data", "tag", "empty_data", "expected_type"),
+    ("data", "tag", "expected_data", "expected_type"),
     [
         pytest.param(
             None,
@@ -74,7 +74,7 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
             SongTag(
                 display_name="Title", id3_key="TIT2", editor_type=EditorType.SingleText
             ),
-            "",
+            "Name",
             EditLineWidget,
             id="line_tag_with_value",
         ),
@@ -85,7 +85,7 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
                 id3_key="TCOM",
                 editor_type=EditorType.MultipleText,
             ),
-            [],
+            ["First Name", "Second Name"],
             EditListWidget,
             id="list_tag_with_multiple_values",
         ),
@@ -96,7 +96,7 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
                 id3_key="TCOM",
                 editor_type=EditorType.MultipleText,
             ),
-            [],
+            ["First Name"],
             EditListWidget,
             id="list_tag_with_single_value",
         ),
@@ -107,9 +107,20 @@ from music_modify.gui.edit.widget_edit_table import EditTableWidget
                 id3_key="TIPL",
                 editor_type=EditorType.PeopleValue,
             ),
-            [],
+            [["role1", "Name 1"], ["role2", "Name 2"]],
             EditTableWidget,
             id="people_tag_with_value",
+        ),
+        pytest.param(
+            "First Name",
+            SongTag(
+                display_name="Composer",
+                id3_key="TCOM",
+                editor_type=EditorType.MultipleText,
+            ),
+            ["First Name"],
+            EditListWidget,
+            id="list_tag_with_string_value",
         ),
     ],
 )
@@ -117,7 +128,7 @@ def test_EditWidgetFactory_createWidget_normal(
     qtbot: QtBot,
     data: str | list[str] | list[list[str]] | None,
     tag: SongTag,
-    empty_data: str | list[str] | list[list[str]],
+    expected_data: str | list[str] | list[list[str]],
     expected_type: type[EditLineWidget] | type[EditListWidget] | type[EditTableWidget],
 ) -> None:
     """Tests that the correct widget types are created based on the tag."""
@@ -127,7 +138,7 @@ def test_EditWidgetFactory_createWidget_normal(
     created_widget = EditWidgetFactory.createWidget(widget, tag, data)
     qtbot.addWidget(created_widget)
     assert isinstance(created_widget, expected_type)
-    assert created_widget.value == (data if data is not None else empty_data)
+    assert created_widget.value == expected_data
 
 
 def test_EditWidgetFactory_createWidget_unsupported_type_raises_error() -> None:

--- a/tests/gui/main/test_gui_main.py
+++ b/tests/gui/main/test_gui_main.py
@@ -15,6 +15,7 @@ import pytest
 from pytestqt.qtbot import QtBot
 
 from music_modify.gui import MainWindow
+from music_modify.prefs import Settings
 
 
 def test_MainWindow_getFolderFiles(
@@ -22,9 +23,10 @@ def test_MainWindow_getFolderFiles(
     song_paths: list[PathLike[str]],
     asset_folder: str,
     num_temp_songs: int,
+    temp_settings: Settings,
 ) -> None:
     """Test that getFolderFiles correctly gets the files from a path."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     files = window.getFolderFiles(asset_folder)
     assert len(files) == num_temp_songs
@@ -35,10 +37,10 @@ def test_MainWindow_addFiles(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Test that addFiles correctly adds the files to the model."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -48,10 +50,10 @@ def test_MainWindow_clearFiles(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Test that clearFiles removes the songs from the model."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -63,10 +65,10 @@ def test_MainWindow_clearFiles_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Test that calling the clearFiles action clears the files."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -78,10 +80,10 @@ def test_MainWindow_setFileActionState(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Test that the state of actions changes based on there being files or not."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     assert not window.action_clear_files.isEnabled()
     window.addFiles(song_paths)
@@ -93,10 +95,12 @@ def test_MainWindow_setFileActionState(
 
 
 def test_MainWindow_setSelectionActionState(
-    qtbot: QtBot, song_paths: list[PathLike[str]], mock_settings: MagicMock
+    qtbot: QtBot,
+    song_paths: list[PathLike[str]],
+    temp_settings: Settings,
 ) -> None:
     """Test that the state of actions changes based on there being a selection."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.action_select_all.isEnabled()
@@ -115,10 +119,10 @@ def test_MainWindow_selectAll_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that calling the select all action selects all songs."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -130,10 +134,10 @@ def test_MainWindow_selectNone_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that calling the select none action clears the selection."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -147,10 +151,10 @@ def test_MainWindow_removeSelectedFiles_normal(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that selected files are removed when there is a selection."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -167,10 +171,10 @@ def test_MainWindow_removeSelectedFiles_none_selected(
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
     caplog: pytest.LogCaptureFixture,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that removing files with none selection creates a log message."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
 
@@ -195,10 +199,10 @@ def test_MainWindow_removeSelectedFiles_all_selected(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that clearFiles is called if removeSelected is called with all selected."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
 
@@ -220,10 +224,10 @@ def test_MainWindow_removeSelectedFiles_Action(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that the action for remove selected triggers the correct change."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     window.addFiles(song_paths)
     assert window.files_table_view.model().rowCount() == num_temp_songs
@@ -239,10 +243,10 @@ def test_MainWindow_updateStatusbarMessage(
     qtbot: QtBot,
     song_paths: list[PathLike[str]],
     num_temp_songs: int,
-    mock_settings: MagicMock,
+    temp_settings: Settings,
 ) -> None:
     """Tests that the statusbar values are updated based on state."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
     assert window.statusLabel.text() == ""
     window.addFiles(song_paths)
@@ -256,7 +260,10 @@ def test_MainWindow_updateStatusbarMessage(
 
 
 def test_MainWindow_addFiles_progress_dialog_canceled(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, song_paths: list[PathLike[str]]
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    song_paths: list[PathLike[str]],
+    temp_settings: Settings,
 ) -> None:
     """Tests cancelling adding files halfway."""
     # Create a local copy of song paths to avoid modifying the fixture.
@@ -271,7 +278,7 @@ def test_MainWindow_addFiles_progress_dialog_canceled(
         ]
         current_song_paths.extend(new_paths)
 
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_progress_dialog_cls = MagicMock()
@@ -310,10 +317,10 @@ def test_MainWindow_addFiles_progress_dialog_canceled(
 
 
 def test_MainWindow_getFolderFiles_progress_dialog_canceled(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests canceling getFolderFiles halfway."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_base_folder = "/mock/base_folder"
@@ -359,12 +366,14 @@ def test_MainWindow_getFolderFiles_progress_dialog_canceled(
     )
 
 
-def test_MainWindow_processTableDragEvent_has_urls(qtbot: QtBot) -> None:
+def test_MainWindow_processTableDragEvent_has_urls(
+    qtbot: QtBot, temp_settings: Settings
+) -> None:
     """Tests processing drag events when valid urls sent.
 
     The action should be accepted, and the data should be processed.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_mime_data = MagicMock(spec=QMimeData)
@@ -380,13 +389,13 @@ def test_MainWindow_processTableDragEvent_has_urls(qtbot: QtBot) -> None:
 
 
 def test_MainWindow_processTableDragEvent_no_urls(
-    qtbot: QtBot, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot, caplog: pytest.LogCaptureFixture, temp_settings: Settings
 ) -> None:
     """Tests processing drag events when no urls are sent.
 
     The action should be rejected, and a log warning should be made.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_mime_data = MagicMock(spec=QMimeData)
@@ -405,13 +414,16 @@ def test_MainWindow_processTableDragEvent_no_urls(
 
 
 def test_MainWindow_processTableDropEvents_drop_files(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, song_paths: list[PathLike[str]]
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    song_paths: list[PathLike[str]],
+    temp_settings: Settings,
 ) -> None:
     """Tests prop events when files are dropped on a table.
 
     Each of the files should be added, if not already present.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_urls = []
@@ -442,12 +454,13 @@ def test_MainWindow_processTableDropEvents_drop_folders(
     monkeypatch: pytest.MonkeyPatch,
     song_paths: list[PathLike[str]],
     asset_folder: str,
+    temp_settings: Settings,
 ) -> None:
     """Tests prop events when folders are dropped on a table.
 
     Each of the files in the folders should be added, if not already present.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_folder_url = MagicMock(spec=QUrl)
@@ -479,13 +492,14 @@ def test_MainWindow_processTableDropEvents_drop_mixed_files_and_folders(
     song_path: Path,
     song_paths: list[PathLike[str]],
     asset_folder: str,
+    temp_settings: Settings,
 ) -> None:
     """Tests dropping files and folders together on a table.
 
     Each of the individual files should be added, if not already present.
     Each of the files in the folders should be added, if not already present.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     # One MP3 file URL
@@ -526,13 +540,13 @@ def test_MainWindow_processTableDropEvents_drop_mixed_files_and_folders(
 
 
 def test_MainWindow_processTableDropEvents_unsupported_mime_data(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests drop events where the mimedata isn't valid.
 
     The action should be rejected, and no files or folders should be added.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_mime_data = MagicMock(spec=QMimeData)
@@ -554,14 +568,14 @@ def test_MainWindow_processTableDropEvents_unsupported_mime_data(
 
 
 def test_MainWindow_addStatusbarMessage_no_app(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that the status bar message isn't added if invalid.
 
     If there isn't a QApplication instance, the text shouldn't be set.
     This should _never_ happen, though.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     monkeypatch.setattr(QApplication, "instance", MagicMock(return_value=None))
@@ -574,10 +588,10 @@ def test_MainWindow_addStatusbarMessage_no_app(
 
 
 def test_MainWindow_showAboutDialog(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that showAboutDialog creates and displays an AboutDialog."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_about_dialog_instance = MagicMock()
@@ -593,10 +607,10 @@ def test_MainWindow_showAboutDialog(
 
 
 def test_MainWindow_showPrefsDialog(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that showPrefsDialog creates and displays an PrefsDialog."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_prefs_dialog_instance = MagicMock()
@@ -610,16 +624,17 @@ def test_MainWindow_showPrefsDialog(
 
     window.showPrefsDialog()
 
-    mock_prefs_dialog_class.assert_called_once_with(parent=window)
-    mock_prefs_dialog_instance.show.assert_called_once()
-    mock_prefs_dialog_instance.settings_updated.connect.assert_called_once_with(
-        mock_refresh_table
+    mock_prefs_dialog_class.assert_called_once_with(
+        parent=window, settings=temp_settings
     )
+    mock_prefs_dialog_instance.show.assert_called_once()
 
 
-def test_MainWindow_refreshTable(qtbot: QtBot, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_MainWindow_refreshTable(
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
+) -> None:
     """Tests that refreshTable updates the repo, model, and view."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     window.songs_repository.refreshDisplay = MagicMock()
@@ -636,15 +651,15 @@ def test_MainWindow_refreshTable(qtbot: QtBot, monkeypatch: pytest.MonkeyPatch) 
 
     window.songs_repository.refreshDisplay.assert_called_once()
     mock_update_table_view.assert_called_once_with(
-        window.files_table_view, window.songs_repository
+        window.files_table_view, window.songs_repository, temp_settings.table_tags
     )
 
 
 def test_MainWindow_showEditDialog_no_selection(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that an EditDialog is not created if there is no selection."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_get_selected_rows = MagicMock(return_value=[])
@@ -662,14 +677,14 @@ def test_MainWindow_showEditDialog_no_selection(
 
 
 def test_MainWindow_showEditDialog_individual_edit_accepted(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests creating an EditDialog for multiple songs, but editing individually.
 
     Tests that the signals for the dialog are connected correctly,
     and that information gets updated when the dialog is accepted.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     selected_rows = [0, 2, 1]  # Unsorted
@@ -692,7 +707,12 @@ def test_MainWindow_showEditDialog_individual_edit_accepted(
     window.showEditDialog(bulk=False)
 
     mock_get_selected_rows.assert_called_once_with(window.files_table_view)
-    mock_dialog_factory_get.assert_called_once_with(expected_sorted_rows, bulk=False)
+    mock_dialog_factory_get.assert_called_once_with(
+        expected_sorted_rows,
+        temp_settings.all_tags,
+        temp_settings.split_text_entered,
+        bulk=False,
+    )
 
     # Verify the info_updated signal is connected to the window's refreshTable method
     mock_edit_dialog_instance.info_updated.connect.assert_called_once_with(
@@ -710,14 +730,14 @@ def test_MainWindow_showEditDialog_individual_edit_accepted(
 
 
 def test_MainWindow_showEditDialog_individual_edit_rejected(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests creating an EditDialog for multiple songs, but editing individually.
 
     Tests that the signals for the dialog are connected correctly,
     and that information does not get updated when the dialog is rejected.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     selected_rows = [0]
@@ -739,7 +759,12 @@ def test_MainWindow_showEditDialog_individual_edit_rejected(
     window.showEditDialog(bulk=False)
 
     mock_get_selected_rows.assert_called_once_with(window.files_table_view)
-    mock_dialog_factory_get.assert_called_once_with(selected_rows, bulk=False)
+    mock_dialog_factory_get.assert_called_once_with(
+        selected_rows,
+        temp_settings.all_tags,
+        temp_settings.split_text_entered,
+        bulk=False,
+    )
     mock_edit_dialog_instance.info_updated.connect.assert_called_once_with(
         window.refreshTable
     )
@@ -753,14 +778,14 @@ def test_MainWindow_showEditDialog_individual_edit_rejected(
 
 
 def test_MainWindow_showEditDialog_bulk_edit_accepted(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests creating an EditDialog for multiple songs, edited in bulk.
 
     Tests that the signals for the dialog are connected correctly,
     and that information gets updated when the dialog is accepted.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     selected_rows = [0, 1]
@@ -782,7 +807,12 @@ def test_MainWindow_showEditDialog_bulk_edit_accepted(
     window.showEditDialog(bulk=True)
 
     mock_get_selected_rows.assert_called_once_with(window.files_table_view)
-    mock_dialog_factory_get.assert_called_once_with(selected_rows, bulk=True)
+    mock_dialog_factory_get.assert_called_once_with(
+        selected_rows,
+        temp_settings.all_tags,
+        temp_settings.split_text_entered,
+        bulk=True,
+    )
     mock_edit_dialog_instance.info_updated.connect.assert_called_once_with(
         window.refreshTable
     )
@@ -807,10 +837,13 @@ def _getMockQFileDialogClass(mock_instance: MagicMock) -> MagicMock:
 
 
 def test_MainWindow_openAddDialog_existing_files(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, song_paths: list[PathLike[str]]
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    song_paths: list[PathLike[str]],
+    temp_settings: Settings,
 ) -> None:
     """Test that openAddDialog processes files and calls add correctly."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_file_dialog_instance = MagicMock()
@@ -842,9 +875,10 @@ def test_MainWindow_openAddDialog_directory_mode(
     monkeypatch: pytest.MonkeyPatch,
     song_paths: list[PathLike[str]],
     asset_folder: str,
+    temp_settings: Settings,
 ) -> None:
     """Test that openAddDialog processes folders and calls add correctly."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_file_dialog_instance = MagicMock()
@@ -876,10 +910,10 @@ def test_MainWindow_openAddDialog_directory_mode(
 
 
 def test_MainWindow_openAddDialog_cancelled(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that files aren't added if the AddDialog is cancelled."""
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_file_dialog_instance = MagicMock()
@@ -927,7 +961,10 @@ class _MockQMenu(MagicMock):
 
 
 def test_MainWindow_showCustomContextMenu_invalid_index(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    qtbot: QtBot,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    temp_settings: Settings,
 ) -> None:
     """Tests that a custom context menu isn't created for an invalid index.
 
@@ -935,7 +972,7 @@ def test_MainWindow_showCustomContextMenu_invalid_index(
 
     This should be logged.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_index = MagicMock()
@@ -961,13 +998,13 @@ def test_MainWindow_showCustomContextMenu_invalid_index(
 
 
 def test_MainWindow_showCustomContextMenu_single_selection(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests creating a custom context menu with only one item selected.
 
     The menu should be created, but there should be no option for bulk editing.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_index = MagicMock()
@@ -1005,14 +1042,14 @@ def test_MainWindow_showCustomContextMenu_single_selection(
 
 
 def test_MainWindow_showCustomContextMenu_multiple_selection(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests creating a custom context menu with multiple items selected.
 
     The menu should be created, and there should be options for bulk editing
     and individual editing.
     """
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_index = MagicMock()
@@ -1068,7 +1105,7 @@ def test_MainWindow_showCustomContextMenu_multiple_selection(
 
 
 def test_MainWindow_action_triggers(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: Settings
 ) -> None:
     """Tests that the actions are linked to the correct slots."""
     # These two need to be done before the class is created,
@@ -1080,7 +1117,7 @@ def test_MainWindow_action_triggers(
     monkeypatch.setattr(QTableView, "selectAll", mock_select_all)
     monkeypatch.setattr(QTableView, "clearSelection", mock_select_none)
 
-    window = MainWindow()
+    window = MainWindow(temp_settings)
     qtbot.addWidget(window)
 
     mock_open_add_dialog = MagicMock()

--- a/tests/gui/prefs/test_dialog_prefs.py
+++ b/tests/gui/prefs/test_dialog_prefs.py
@@ -1,9 +1,10 @@
 """Tests for PrefsDialog."""
 
+# pyright: reportUnusedParameter = false
+
 from typing import TYPE_CHECKING, cast, override
 from unittest.mock import MagicMock
 
-from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QVBoxLayout, QWidget
 import pytest
 from pytestqt.qtbot import QtBot
@@ -12,6 +13,7 @@ from music_modify.gui.prefs.dialog_prefs import PrefsDialog
 from music_modify.gui.prefs.dialog_prefs_abstract import PrefsAbstractDialog
 from music_modify.gui.prefs.dialog_prefs_split import PrefsSplitDialog
 from music_modify.gui.prefs.dialog_prefs_tag import PrefsTagDialog
+from music_modify.prefs import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,10 +23,8 @@ if TYPE_CHECKING:
 class _MockAbstractChildDialog(PrefsAbstractDialog):
     """A mock dialog for testing the generic behaviour of openChildDialog."""
 
-    settings_updated: Signal = Signal()
-
-    def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
+    def __init__(self, settings: Settings, parent: QWidget | None = None) -> None:
+        super().__init__(settings, parent)
         self.setModal: Callable[[bool, Any], None] = MagicMock()
         self.show: Callable[..., None] = MagicMock()
 
@@ -45,69 +45,75 @@ class _MockAbstractChildDialog(PrefsAbstractDialog):
         pass
 
 
-def test_PrefsDialog_openChildDialog_logic(qtbot: QtBot) -> None:
-    """Test that a child dialog is created, and the signals are set up."""
-    child_dialog = _MockAbstractChildDialog()
+def test_PrefsDialog_openChildDialog(
+    qtbot: QtBot, app_info: tuple[str, str, str]
+) -> None:
+    """Test that a child dialog is created."""
+    settings = Settings()
+    settings.configureForApplication()
+
+    child_dialog = _MockAbstractChildDialog(settings)
     qtbot.addWidget(child_dialog)
     child_dialog_class: type[PrefsAbstractDialog] = cast(
         type[PrefsAbstractDialog],
         MagicMock(return_value=child_dialog),
     )
 
-    parent_dialog = PrefsDialog()
+    parent_dialog = PrefsDialog(settings)
     qtbot.addWidget(parent_dialog)
 
     parent_dialog.openChildDialog(child_dialog_class)
 
-    cast(MagicMock, child_dialog_class).assert_called_once_with(parent_dialog)
+    cast(MagicMock, child_dialog_class).assert_called_once_with(settings, parent_dialog)
     cast(MagicMock, child_dialog.setModal).assert_called_once_with(True)
     cast(MagicMock, child_dialog.show).assert_called_once()
 
-    with qtbot.waitSignal(parent_dialog.settings_updated, timeout=1000):
-        child_dialog.settings_updated.emit()
-
 
 def test_PrefsDialog_buttonEditTags_opensTagDialog(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, app_info: tuple[str, str, str]
 ) -> None:
     """Test that clicking Edit Tags button opens a PrefsTagDialog."""
     tag_dialog_instance = MagicMock(spec=PrefsTagDialog)
     tag_dialog_class = MagicMock(return_value=tag_dialog_instance)
+
+    settings = Settings()
+    settings.configureForApplication()
 
     monkeypatch.setattr(
         "music_modify.gui.prefs.dialog_prefs.PrefsTagDialog",
         tag_dialog_class,
     )
 
-    dialog = PrefsDialog()
+    dialog = PrefsDialog(settings)
     qtbot.addWidget(dialog)
 
     dialog.button_edit_tags.click()
 
-    tag_dialog_class.assert_called_once_with(dialog)
+    tag_dialog_class.assert_called_once_with(settings, dialog)
     tag_dialog_instance.setModal.assert_called_once_with(True)
     tag_dialog_instance.show.assert_called_once()
 
 
 def test_PrefsDialog_buttonEditTags_opensSplitDialog(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
+    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, app_info: tuple[str, str, str]
 ) -> None:
     """Test that clicking Edit Split button opens a PrefsSplitDialog."""
     split_dialog_instance = MagicMock(spec=PrefsSplitDialog)
     split_dialog_class = MagicMock(return_value=split_dialog_instance)
+
+    settings = Settings()
+    settings.configureForApplication()
 
     monkeypatch.setattr(
         "music_modify.gui.prefs.dialog_prefs.PrefsSplitDialog",
         split_dialog_class,
     )
 
-    dialog = PrefsDialog()
+    dialog = PrefsDialog(settings)
     qtbot.addWidget(dialog)
 
     dialog.button_edit_split.click()
 
-    split_dialog_class.assert_called_once_with(dialog)
+    split_dialog_class.assert_called_once_with(settings, dialog)
     split_dialog_instance.setModal.assert_called_once_with(True)
     split_dialog_instance.show.assert_called_once()

--- a/tests/gui/prefs/test_dialog_prefs_abstract.py
+++ b/tests/gui/prefs/test_dialog_prefs_abstract.py
@@ -6,9 +6,12 @@ import pytest
 from pytestqt.qtbot import QtBot
 
 from music_modify.gui.prefs.dialog_prefs_abstract import PrefsAbstractDialog
+from music_modify.prefs import Settings
 
 
-def test_prefsAbstractDialog_missingLayout(qtbot: QtBot) -> None:
+def test_prefsAbstractDialog_missingLayout(
+    qtbot: QtBot, temp_settings: Settings
+) -> None:
     """Test that if the dialog doesn't set layout, there is an exception."""
 
     class TestDialogWithoutLayout(PrefsAbstractDialog):
@@ -34,7 +37,7 @@ def test_prefsAbstractDialog_missingLayout(qtbot: QtBot) -> None:
 
     w: TestDialogWithoutLayout | None = None
     with pytest.raises(Exception, match=expected_exception_message) as excinfo:
-        w = TestDialogWithoutLayout()
+        w = TestDialogWithoutLayout(temp_settings)
     if w:
         qtbot.addWidget(w)
 

--- a/tests/gui/prefs/test_dialog_prefs_split.py
+++ b/tests/gui/prefs/test_dialog_prefs_split.py
@@ -1,29 +1,21 @@
 """Tests for PrefsSplitDialog."""
 
 from PySide6.QtWidgets import QDialogButtonBox
-import pytest
 from pytestqt.qtbot import QtBot
 
 from music_modify.gui.prefs.dialog_prefs_split import PrefsSplitDialog
-import music_modify.prefs.prefs as prefs_module
+from music_modify.prefs import Settings
 
 
-def _createDialog(
-    qtbot: QtBot, monkeypatch: pytest.MonkeyPatch, temp_settings: prefs_module.Settings
-) -> PrefsSplitDialog:
-    monkeypatch.setattr(prefs_module, "settings", temp_settings)
-    split_dialog = PrefsSplitDialog()
+def _createDialog(qtbot: QtBot, temp_settings: Settings) -> PrefsSplitDialog:
+    split_dialog = PrefsSplitDialog(temp_settings)
     qtbot.addWidget(split_dialog)
     return split_dialog
 
 
-def test_prefsSplitDialog_init(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
-) -> None:
+def test_prefsSplitDialog_init(qtbot: QtBot, temp_settings: Settings) -> None:
     """Test that a PrefsSplitDialog is created correctly."""
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     assert (
         split_dialog.line_edit_split_text_entered.text()
@@ -39,12 +31,10 @@ def test_prefsSplitDialog_init(
 
 
 def test_prefsSplitDialog_line_edit_single(
-    qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    qtbot: QtBot, temp_settings: Settings
 ) -> None:
     """Test that modifying the value for one line edit updates changed_settings."""
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     split_dialog.line_edit_split_text_entered.setText("++")
     split_dialog.line_edit_split_text_entered.editingFinished.emit()
@@ -59,11 +49,10 @@ def test_prefsSplitDialog_line_edit_single(
 
 def test_prefsSplitDialog_line_edit_multiple(
     qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Test that modifying values for multiple line edits updates changed_settings."""
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     split_dialog.line_edit_split_text_entered.setText("++")
     split_dialog.line_edit_split_text_entered.editingFinished.emit()
@@ -106,11 +95,10 @@ def test_prefsSplitDialog_line_edit_multiple(
 
 def test_prefsSplitDialog_updateSettings(
     qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Test that updateSettings modifies the stored settings values."""
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     split_dialog.line_edit_split_text_entered.setText("++")
     split_dialog.line_edit_split_text_entered.editingFinished.emit()
@@ -127,11 +115,10 @@ def test_prefsSplitDialog_updateSettings(
 
 def test_prefsSplitDialog_restoreDefaults(
     qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Test the restoreDefaults modifies the values to be the original defaults."""
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     split_dialog.line_edit_split_text_entered.setText("++")
     split_dialog.line_edit_split_text_entered.editingFinished.emit()
@@ -161,14 +148,13 @@ def test_prefsSplitDialog_restoreDefaults(
 
 def test_prefsSplitDialog_resetSettings(
     qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that resetSettings sets values to be the same as they were on opening."""
     temp_settings.split_text_entered = "::"
     temp_settings.split_values_display = "::"
     temp_settings.split_values_at = "::"
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     # Ensure that nothing changes if settings is empty
     split_dialog.resetSettings()
@@ -194,15 +180,14 @@ def test_prefsSplitDialog_resetSettings(
 
 def test_prefsSplitDialog_line_edit_empty(
     qtbot: QtBot,
-    monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that an empty line edit removes values from changed_settings.
 
     Changed settings should store the changes that need to be made.
     With an empty line edit, this indicates no changes should be made for that item.
     """
-    split_dialog = _createDialog(qtbot, monkeypatch, temp_settings)
+    split_dialog = _createDialog(qtbot, temp_settings)
 
     split_dialog.line_edit_split_text_entered.setText("")
     split_dialog.line_edit_split_text_entered.editingFinished.emit()

--- a/tests/gui/prefs/test_dialog_prefs_tag.py
+++ b/tests/gui/prefs/test_dialog_prefs_tag.py
@@ -12,7 +12,7 @@ from music_modify.custom_types.tag_info import TagInfo
 from music_modify.gui.prefs.dialog_prefs_tag import PrefsTagDialog
 from music_modify.gui.utils import selectRows
 from music_modify.models.tag_model import TagModel
-import music_modify.prefs.prefs as prefs_module
+from music_modify.prefs import Settings
 
 _test_tag_info = TagInfo(
     id3_key="TEST",
@@ -45,19 +45,17 @@ class _MockPrefsTagAddDialog(QObject):
 def _createDialog(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> PrefsTagDialog:
-    _patchDialogs(monkeypatch, temp_settings)
-    dialog = PrefsTagDialog()
+    _patchDialogs(monkeypatch)
+    dialog = PrefsTagDialog(temp_settings)
     qtbot.addWidget(dialog)
     return dialog
 
 
 def _patchDialogs(
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
 ) -> None:
-    monkeypatch.setattr(prefs_module, "settings", temp_settings)
     monkeypatch.setattr(
         QMessageBox,
         "warning",
@@ -106,7 +104,7 @@ def _makeChanges(
 def test_PrefsTagDialog_init(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that creating a PrefsTagDialog works correctly."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -116,7 +114,7 @@ def test_PrefsTagDialog_init(
 def test_PrefsTagDialog_addTag(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that adding a valid tag to the dialog adds it."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -132,7 +130,7 @@ def test_PrefsTagDialog_addTag(
 def test_PrefsTagDialog_removeSelectedTags(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that removing the selected rows works."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -165,7 +163,7 @@ def test_PrefsTagDialog_removeSelectedTags(
 def test_PrefsTagDialog_moveTagsUp(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that moving tags up in the model works."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -202,7 +200,7 @@ def test_PrefsTagDialog_moveTagsUp(
 def test_PrefsTagDialog_moveTagsDown(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that moving tags down in the model works."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -239,7 +237,7 @@ def test_PrefsTagDialog_moveTagsDown(
 def test_PrefsTagDialog_updateSettings(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that calling updateSettings makes changes to the settings values."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -257,7 +255,7 @@ def test_PrefsTagDialog_updateSettings(
 def test_PrefsTagDialog_restoreDefaults(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that calling restoreDefaults puts the values back to their defaults."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -274,7 +272,7 @@ def test_PrefsTagDialog_restoreDefaults(
 def test_PrefsTagDialog_resetSettings(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that calling resetSettings puts the values back to initial values."""
     dialog1 = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -308,7 +306,7 @@ def test_PrefsTagDialog_resetSettings(
 def test_PrefsTagDialog_restore_then_reset(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Tests that restoring defaults then calling reset puts initial values back."""
     dialog1 = _createDialog(qtbot, monkeypatch, temp_settings)
@@ -348,7 +346,7 @@ def test_PrefsTagDialog_restore_then_reset(
 def test_PrefsTagDialog_showInvalidInputMessage(
     qtbot: QtBot,
     monkeypatch: pytest.MonkeyPatch,
-    temp_settings: prefs_module.Settings,
+    temp_settings: Settings,
 ) -> None:
     """Test that an invalid input message is shown when needed."""
     dialog = _createDialog(qtbot, monkeypatch, temp_settings)

--- a/tests/models/test_song_models.py
+++ b/tests/models/test_song_models.py
@@ -4,10 +4,10 @@
 
 from os import PathLike
 from pathlib import Path
-from unittest.mock import MagicMock
 
 from PySide6.QtCore import Qt
 
+from music_modify.custom_types.songtag import SongTag
 from music_modify.models import SongRepository, SongTableModel
 
 
@@ -17,8 +17,8 @@ def test_SongTableModel_init() -> None:
     It should have no rows, but one column,
     and the header should display the empty message.
     """
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository([], [], "")
+    model = SongTableModel(repo, [])
     assert model.rowCount() == 0
     assert model.columnCount() == 1
     assert (
@@ -27,19 +27,19 @@ def test_SongTableModel_init() -> None:
     )
 
 
-def test_SongTableModel_songs_added(song_path: Path, mock_settings: MagicMock) -> None:
+def test_SongTableModel_songs_added(song_path: Path, table_tags: list[SongTag]) -> None:
     """Test that the model is updated when songs are added to the repo."""
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository(table_tags, table_tags, "")
+    model = SongTableModel(repo, table_tags)
     repo.addFile(song_path)
     assert model.rowCount() == 1
-    assert model.columnCount() == len(mock_settings.table_tags)
+    assert model.columnCount() == len(table_tags)
 
 
 def test_SongTableModel_headerData_no_songs() -> None:
     """Test that vertical headers don't exist when there is no song data."""
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository([], [], "")
+    model = SongTableModel(repo, [])
     assert (
         model.headerData(
             len(repo),
@@ -55,11 +55,11 @@ def test_SongTableModel_headerData_no_songs() -> None:
 
 
 def test_SongTableModel_headerData_songs_added(
-    song_paths: list[PathLike[str]], mock_settings: MagicMock
+    song_paths: list[PathLike[str]], table_tags: list[SongTag]
 ) -> None:
     """Test that headers display when songs are added."""
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository(table_tags, table_tags, "")
+    model = SongTableModel(repo, table_tags)
     repo.addFiles(song_paths)
     assert len(repo) > 0
     assert (
@@ -72,7 +72,7 @@ def test_SongTableModel_headerData_songs_added(
     )
     assert (
         model.headerData(0, Qt.Orientation.Horizontal, Qt.ItemDataRole.DisplayRole)
-        == mock_settings.table_tags[0].display_name
+        == table_tags[0].display_name
     )
     assert (
         model.headerData(0, Qt.Orientation.Horizontal, Qt.ItemDataRole.EditRole) is None
@@ -84,7 +84,7 @@ def test_SongTableModel_headerData_songs_added(
     # Invalid section indexes should be None
     assert (
         model.headerData(
-            len(mock_settings.table_tags),
+            len(table_tags),
             Qt.Orientation.Horizontal,
             Qt.ItemDataRole.DisplayRole,
         )
@@ -102,21 +102,21 @@ def test_SongTableModel_headerData_songs_added(
 
 def test_SongTableModel_data_no_songs() -> None:
     """Test that data is None when there are no songs."""
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository([], [], "")
+    model = SongTableModel(repo, [])
 
     assert model.data(model.index(0, 0), Qt.ItemDataRole.DisplayRole) is None
 
 
 def test_SongTableModel_data(
-    song_paths: list[PathLike[str]], mock_settings: MagicMock
+    song_paths: list[PathLike[str]], table_tags: list[SongTag]
 ) -> None:
     """Test that data returns the correct type when songs exist.
 
     Assuming that a valid role and index is used.
     """
-    repo = SongRepository()
-    model = SongTableModel(repo)
+    repo = SongRepository(table_tags, table_tags, "")
+    model = SongTableModel(repo, table_tags)
     repo.addFiles(song_paths)
     assert model.rowCount() == len(song_paths)
 

--- a/tests/models/test_song_repository.py
+++ b/tests/models/test_song_repository.py
@@ -1,7 +1,5 @@
 """Tests for SongRepository."""
 
-# pyright: reportUnusedParameter = false, reportMissingSuperCall = false
-
 from os import PathLike
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -10,42 +8,29 @@ import pytest
 from pytestqt.qtbot import QtBot
 
 from music_modify.custom_types.song import Song
+from music_modify.custom_types.songtag import SongTag
 from music_modify.models.song_repository import SongRepository
 
 
-class _MockSong(Song):
-    """Mock the Song class to not call __init__."""
-
-    def __init__(self, file: str | PathLike[str] | None = None) -> None:
-        """Deliberately _not_ calling super, so we don't need to stress about prefs."""
-        self.file = file
-
-
-@pytest.fixture
-def mock_song(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fixture for mocking the Song class."""
-    monkeypatch.setattr("music_modify.models.song_repository.Song", _MockSong)
-
-
-def test_SongRepository_getSong_invalid_index() -> None:
+def test_SongRepository_getSong_invalid_index(table_tags: list[SongTag]) -> None:
     """Test that None is returned when trying to get a song at an invalid index."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     assert repo.getSong(0) is None
     assert repo[1] is None
 
 
-def test_SongRepository_getSong_valid_index(mock_song: None) -> None:
+def test_SongRepository_getSong_valid_index(table_tags: list[SongTag]) -> None:
     """Test that a Song is returned when using a valid index."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addSong()
     assert isinstance(repo.getSong(0), Song)
     assert isinstance(repo[0], Song)
 
 
-def test_SongRepository_contains(song_path: Path, mock_song: None) -> None:
+def test_SongRepository_contains(song_path: Path, table_tags: list[SongTag]) -> None:
     """Test that contains returns True if the song is present, otherwise False."""
-    repo = SongRepository()
-    song1 = _MockSong()
+    repo = SongRepository(table_tags, table_tags, ", ")
+    song1 = Song(table_tags, table_tags, ", ")
     assert (song1 in repo) is False
     repo.addSong(song1)
     assert (song1 in repo) is True
@@ -55,10 +40,10 @@ def test_SongRepository_contains(song_path: Path, mock_song: None) -> None:
 
 
 def test_SongRepository_addFile_single(
-    song_path: Path, qtbot: QtBot, mock_song: None
+    song_path: Path, qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that adding a file that doesn't exist works."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.addFile(song_path)
     assert len(repo) == 1
@@ -67,10 +52,10 @@ def test_SongRepository_addFile_single(
 
 
 def test_SongRepository_addFile_exists_rejected(
-    song_path: Path, qtbot: QtBot, mock_song: None
+    song_path: Path, qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Tests that adding a file that exists doesn't add it again."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.addFile(song_path)
     with qtbot.assertNotEmitted(repo.songs_updated):
@@ -80,19 +65,23 @@ def test_SongRepository_addFile_exists_rejected(
     assert song.file == song_path
 
 
-def test_SongRepository_addSong_with_song(qtbot: QtBot, mock_song: None) -> None:
+def test_SongRepository_addSong_with_song(
+    qtbot: QtBot, table_tags: list[SongTag]
+) -> None:
     """Tests that calling addSong with a song adds it the repo."""
-    repo = SongRepository()
-    song = _MockSong()
+    repo = SongRepository(table_tags, table_tags, ", ")
+    song = Song(table_tags, table_tags, ", ")
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.addSong(song)
     assert len(repo) == 1
     assert repo[0] == song
 
 
-def test_SongRepository_addSong_with_None(qtbot: QtBot, mock_song: None) -> None:
+def test_SongRepository_addSong_with_None(
+    qtbot: QtBot, table_tags: list[SongTag]
+) -> None:
     """Tests that calling addSong with None creates a song and adds it."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.addSong()
     assert len(repo) == 1
@@ -100,10 +89,10 @@ def test_SongRepository_addSong_with_None(qtbot: QtBot, mock_song: None) -> None
 
 
 def test_SongRepository_addFiles_adds_multiple(
-    song_paths: list[PathLike[str]], mock_song: None
+    song_paths: list[PathLike[str]], table_tags: list[SongTag]
 ) -> None:
     """Test that multiple songs are added when calling addFiles."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.songs_updated = MagicMock()
     repo.songs_updated.emit = MagicMock()
     repo.addFiles(song_paths)
@@ -115,10 +104,10 @@ def test_SongRepository_addFiles_adds_multiple(
 
 
 def test_SongRepository_clearFiles(
-    song_path: Path, qtbot: QtBot, mock_song: None
+    song_path: Path, qtbot: QtBot, table_tags: list[SongTag]
 ) -> None:
     """Test that clearing files makes the repo empty."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addFile(song_path)
     assert len(repo) > 0
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
@@ -127,10 +116,12 @@ def test_SongRepository_clearFiles(
 
 
 def test_SongRepository_removeSongs_single(
-    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
+    song_paths: list[PathLike[str]],
+    qtbot: QtBot,
+    table_tags: list[SongTag],
 ) -> None:
     """Test that removing a single song from the repo works."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addFiles(song_paths)
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.removeSongs([0])
@@ -139,10 +130,12 @@ def test_SongRepository_removeSongs_single(
 
 
 def test_SongRepository_removeSongs_multiple(
-    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
+    song_paths: list[PathLike[str]],
+    qtbot: QtBot,
+    table_tags: list[SongTag],
 ) -> None:
     """Test that removing multiple songs from the repo works."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addFiles(song_paths)
     with qtbot.waitSignal(repo.songs_updated, timeout=1000):
         repo.removeSongs([0, 1])
@@ -151,10 +144,12 @@ def test_SongRepository_removeSongs_multiple(
 
 
 def test_SongRepository_removeSongs_empty_indexes(
-    song_paths: list[PathLike[str]], qtbot: QtBot, mock_song: None
+    song_paths: list[PathLike[str]],
+    qtbot: QtBot,
+    table_tags: list[SongTag],
 ) -> None:
     """Test that the repo doesn't change, and songs_updated isn't emitted."""
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     repo.addFiles(song_paths)
     with qtbot.assertNotEmitted(repo.songs_updated):
         repo.removeSongs([])
@@ -162,7 +157,7 @@ def test_SongRepository_removeSongs_empty_indexes(
 
 
 def test_SongRepository_refreshDisplay(
-    monkeypatch: pytest.MonkeyPatch, mock_song: None
+    monkeypatch: pytest.MonkeyPatch, table_tags: list[SongTag]
 ) -> None:
     """Test that refreshDisplay calls updateInfo for each song in songs."""
     mock_update_info = MagicMock()
@@ -170,7 +165,7 @@ def test_SongRepository_refreshDisplay(
 
     num_songs = 3
 
-    repo = SongRepository()
+    repo = SongRepository(table_tags, table_tags, ", ")
     for _ in range(num_songs):
         repo.addSong()
 

--- a/tests/prefs/test_prefs.py
+++ b/tests/prefs/test_prefs.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QApplication
 import pytest
 
 from music_modify.custom_types import SongTag, TagInfo
-from music_modify.prefs.prefs import Settings
+from music_modify.prefs import Settings
 
 
 def _set_split_values(settings: Settings) -> None:


### PR DESCRIPTION
Instead of using a global instance for settings, create an instance and pass in the attributes where needed.

This makes it clearer about imports, and dependencies, and also neatens tests.

Resolves #5.